### PR TITLE
unset svgwrite debug mode

### DIFF
--- a/svgpathtools/paths2svg.py
+++ b/svgpathtools/paths2svg.py
@@ -276,9 +276,9 @@ def disvg(paths=None, colors=None,
 
     # Create an SVG file
     if svg_attributes:
-        dwg = Drawing(filename=filename, **svg_attributes)
+        dwg = Drawing(filename=filename, debug=False, **svg_attributes)
     else:
-        dwg = Drawing(filename=filename, size=(szx, szy), viewBox=viewbox)
+        dwg = Drawing(filename=filename, size=(szx, szy), viewBox=viewbox, debug=False)
 
     # add paths
     if paths:


### PR DESCRIPTION
Debug flag is set by default so that svgwrite do some validation stuff.
If you pass paths with many segments or generally a lot of paths svgwrite
takes a lot of time for validation. The paths that svgpathtools fed are
all of correct syntax and bad attributes are ignored by almost all programs
that handled with SVG. So, setting svgwrite debug to False is good choice.