### PR TITLE
README: fix a type error in Offseting Paths example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -587,7 +587,7 @@ curve <https://en.wikipedia.org/wiki/Parallel_curve>`__ for a few paths.
         for seg in path:
             ct = 1
             for k in range(steps):
-                t = k / steps
+                t = k / float(steps)
                 offset_vector = offset_distance * seg.normal(t)
                 nl = Line(seg.point(t), seg.point(t) + offset_vector)
                 nls.append(nl)

--- a/README.rst
+++ b/README.rst
@@ -585,7 +585,6 @@ curve <https://en.wikipedia.org/wiki/Parallel_curve>`__ for a few paths.
         of the 'parallel' offset curve."""
         nls = []
         for seg in path:
-            ct = 1
             for k in range(steps):
                 t = k / float(steps)
                 offset_vector = offset_distance * seg.normal(t)


### PR DESCRIPTION
This PR addresses a couple of minor problems with the Offsetting Paths example in the README.