### PR TITLE
Remove explicitly installing requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,19 +47,6 @@ Prerequisites
 Setup
 -----
 
-If not already installed, you can **install the prerequisites** using
-pip.
-
-.. code:: bash
-
-    $ pip install numpy
-
-.. code:: bash
-
-    $ pip install svgwrite
-
-Then **install svgpathtools**:
-
 .. code:: bash
 
     $ pip install svgpathtools


### PR DESCRIPTION
Since a PIP package has requirements data in it, when installing that package, if requirements have not already been installed, PIP handles installing them automatically. There is no need to install them explicitly.