### PR TITLE
Cache arc length

### DIFF
--- a/svgpathtools/path.py
+++ b/svgpathtools/path.py
@@ -1330,6 +1330,9 @@ class Arc(object):
         # Derive derived parameters
         self._parameterize()
 
+    def __hash__(self):
+        return hash((self.start, self.radius, self.rotation, self.large_arc, self.sweep, self.end))
+
     def __repr__(self):
         params = (self.start, self.radius, self.rotation,
                   self.large_arc, self.sweep, self.end)


### PR DESCRIPTION
Arc.length() can be very slow.  This PR teaches Arc to cache the computed length, so subsequent calls are faster.  It verifies the validity of the cache by hashing the arc parameters.

This speeds one particular workload up from 1m 10s to ~4s, and another, larger workload goes from 19m 23s to 6m 40s.