### PR TITLE
test: show arguments that failed, to aid debugging

### DIFF
--- a/test/test_path.py
+++ b/test/test_path.py
@@ -645,7 +645,7 @@ class ArcTest(unittest.TestCase):
                 orig_t = random.random()
                 p = a.point(orig_t)
                 computed_t = a.point_to_t(p)
-                self.assertAlmostEqual(orig_t, computed_t)
+                self.assertAlmostEqual(orig_t, computed_t, msg="arc %s at t=%f is point %s, but got %f back" % (a, orig_t, p, computed_t))
 
 
 class TestPath(unittest.TestCase):


### PR DESCRIPTION
The `ArcTest.test_point_to_t()` test generates random arcs and random t values, and verifies that `point_to_t(point(t)) == t`.
This commit makes the assert message include the arc, the two t values, and the point, to aid debugging.