### PR TITLE
fix polyline and polygon conversion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import codecs
 import os
 
 
-VERSION = '1.3.4'
+VERSION = '1.3.3'
 AUTHOR_NAME = 'Andy Port'
 AUTHOR_EMAIL = 'AndyAPort@gmail.com'
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import codecs
 import os
 
 
-VERSION = '1.3.3'
+VERSION = '1.3.4'
 AUTHOR_NAME = 'Andy Port'
 AUTHOR_EMAIL = 'AndyAPort@gmail.com'
 

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -47,10 +47,10 @@ def ellipse2pathd(ellipse):
     return d
 
 
-def polyline2pathd(polyline_d, is_polygon=False):
+def polyline2pathd(polyline, is_polygon=False):
     """converts the string from a polyline points-attribute to a string for a
     Path object d-attribute"""
-    points = COORD_PAIR_TMPLT.findall(polyline_d)
+    points = COORD_PAIR_TMPLT.findall(polyline.get('points', ''))
     closed = (float(points[0][0]) == float(points[-1][0]) and
               float(points[0][1]) == float(points[-1][1]))
 
@@ -66,13 +66,13 @@ def polyline2pathd(polyline_d, is_polygon=False):
     return d
 
 
-def polygon2pathd(polyline_d):
+def polygon2pathd(polyline):
     """converts the string from a polygon points-attribute to a string 
     for a Path object d-attribute.
     Note:  For a polygon made from n points, the resulting path will be
     composed of n lines (even if some of these lines have length zero).
     """
-    return polyline2pathd(polyline_d, True)
+    return polyline2pathd(polyline, True)
 
 
 def rect2pathd(rect):
@@ -152,14 +152,14 @@ def svg2paths(svg_file_location,
     # path strings, add to list
     if convert_polylines_to_paths:
         plins = [dom2dict(el) for el in doc.getElementsByTagName('polyline')]
-        d_strings += [polyline2pathd(pl['points']) for pl in plins]
+        d_strings += [polyline2pathd(pl) for pl in plins]
         attribute_dictionary_list += plins
 
     # Use minidom to extract polygon strings from input SVG, convert to
     # path strings, add to list
     if convert_polygons_to_paths:
         pgons = [dom2dict(el) for el in doc.getElementsByTagName('polygon')]
-        d_strings += [polygon2pathd(pg['points']) for pg in pgons]
+        d_strings += [polygon2pathd(pg) for pg in pgons]
         attribute_dictionary_list += pgons
 
     if convert_lines_to_paths:


### PR DESCRIPTION
When svg file that contains polylines or polygons  is converted to paths using Document method flatten_all_paths() an exception occurring in polyline2pathd() method:
TypeError: expected string or bytes-like object

Changing polyline2pathd() method to receive polyline instead of polyline_d makes both methods: flatten_all_paths() and svg2paths() working correctly when converting polylines and polygons.