### PR TITLE
Support flattening paths of only nested groups

### DIFF
--- a/svgpathtools/document.py
+++ b/svgpathtools/document.py
@@ -209,7 +209,7 @@ def flatten_group(group_to_flatten, root, recursive=True,
                 break
 
         if route is None:
-            raise ValueError('The group_to_flatten is not an ancestor of the root!')
+            raise ValueError('The group_to_flatten is not a descendant of the root!')
 
     def desired_group_filter(x):
         return (id(x) in desired_groups) and group_filter(x)

--- a/svgpathtools/document.py
+++ b/svgpathtools/document.py
@@ -73,6 +73,7 @@ CONVERT_ONLY_PATHS = {'path': path2pathd}
 
 SVG_GROUP_TAG = 'svg:g'
 
+
 def flatten_all_paths(group, group_filter=lambda x: True,
                       path_filter=lambda x: True, path_conversions=CONVERSIONS,
                       group_search_xpath=SVG_GROUP_TAG):

--- a/svgpathtools/document.py
+++ b/svgpathtools/document.py
@@ -184,7 +184,7 @@ def flatten_group(group_to_flatten, root, recursive=True,
         while search:
             top = search.pop(0)
             frontier = top[-1]
-            for child in frontier.iterfind('svg:g', SVG_NAMESPACE):
+            for child in frontier.iterfind(group_search_xpath, SVG_NAMESPACE):
                 if child is group_to_flatten:
                     route = top
                     break

--- a/svgpathtools/document.py
+++ b/svgpathtools/document.py
@@ -327,6 +327,20 @@ class Document:
         return any(group is owned for owned in self.tree.iter())
 
     def get_group(self, nested_names, name_attr='id'):
+        """Get a group from the tree, or None if the requested group
+        does not exist. Use get_or_add_group(~) if you want a new group
+        to be created if it did not already exist.
+
+        `nested_names` is a list of strings which represent group names.
+        Each group name will be nested inside of the previous group name.
+
+        `name_attr` is the group attribute that is being used to
+        represent the group's name. Default is 'id', but some SVGs may
+        contain custom name labels, like 'inkscape:label'.
+
+        Returns the request group. If the requested group did not
+        exist, this function will return a None value.
+        """
         group = self.tree.getroot()
         # Drill down through the names until we find the desired group
         while len(nested_names):

--- a/test/test_groups.py
+++ b/test/test_groups.py
@@ -168,7 +168,7 @@ class TestGroups(unittest.TestCase):
     def test_nested_group(self):
         # A bug in the flatten_group() implementation made it so that only top-level
         # groups could have their paths flattened. This is a regression test to make
-        # sure that when a nested group is request, its paths can also be flattened.
+        # sure that when a nested group is requested, its paths can also be flattened.
         doc = Document(join(dirname(__file__), 'groups.svg'))
         result = doc.flatten_group(['matrix group', 'scale group'])
         self.assertEqual(len(result), 5)

--- a/test/test_groups.py
+++ b/test/test_groups.py
@@ -165,6 +165,14 @@ class TestGroups(unittest.TestCase):
 
         self.assertEqual(expected_count, count)
 
+    def test_nested_group(self):
+        # A bug in the flatten_group() implementation made it so that only top-level
+        # groups could have their paths flattened. This is a regression test to make
+        # sure that when a nested group is request, its paths can also be flattened.
+        doc = Document(join(dirname(__file__), 'groups.svg'))
+        result = doc.flatten_group(['matrix group', 'scale group'])
+        self.assertEqual(len(result), 5)
+
     def test_add_group(self):
         # Test `Document.add_group()` function and related Document functions.
         doc = Document(None)


### PR DESCRIPTION
It turns out the current behavior of `document.flatten_group(group)` is not very good when `group` is a child of other groups, because it will always just return no paths at all. The `flatten_group(~)` function did not create a suitable `desired_group_filter(~)`, and as a result its call to `flatten_all_paths(~)` would quit immediately instead of finding its way to the desired group.

This PR changes the behavior so that the groups leading up to the desired group will be added to the `desired_group_filter` created by the `flatten_group(~)` function. Additionally, any paths that are direct children of the desired group's ancestor groups will be filtered out using `desired_path_filter`.

A regression test has been added for this (`test.test_groups.test_nested_group`), and you can see that it fails without these changes.

Additionally, I modified `document.flatten_group(~)` to use a new function `document.get_group(~)` instead of `document.get_or_add_group(~)` because the latter would accidentally create new groups in the document whenever a typo was made in the argument to `document.flatten_group(~)`. That behavior was extremely problematic for me and resulted in several hours of confused debugging before I realized what was happening. The overall behavior will remain the same, but now `document.flatten_group(~)` will never ever modify the contents of `document`, and a warning gets printed when the group cannot be found.