### PR TITLE
Fixed MutableSequence import (importing from collections is deprecated)

### DIFF
--- a/svgpathtools/path.py
+++ b/svgpathtools/path.py
@@ -6,7 +6,10 @@ Arc."""
 from __future__ import division, absolute_import, print_function
 from math import sqrt, cos, sin, acos, asin, degrees, radians, log, pi, ceil
 from cmath import exp, sqrt as csqrt, phase
-from collections import MutableSequence
+try:
+    from collections.abc import MutableSequence  # noqa
+except ImportError:
+    from collections import MutableSequence  # noqa
 from warnings import warn
 from operator import itemgetter
 import numpy as np


### PR DESCRIPTION
Importing `MutableSequence` from `collections` is deprecated and leads to annoying warnings for dependent projects using `pytest`:

```
venv/lib/python3.7/site-packages/svgpathtools/path.py:9
  .../venv/lib/python3.7/site-packages/svgpathtools/path.py:9: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import MutableSequence

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

This fix should be backward compatible ([reference](https://stackoverflow.com/a/53978543/229511)).
