### PR TITLE
Fixed crash in line2pathd()

### DIFF
--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -93,8 +93,8 @@ def rect2pathd(rect):
 
 def line2pathd(l):
     return (
-        'M' + l.attrib['x1'] + ' ' + l.attrib['y1']
-        + 'L' + l.attrib['x2'] + ' ' + l.attrib['y2']
+        'M' + l.attrib.get('x1', '0') + ' ' + l.attrib.get('y1', '0')
+        + 'L' + l.attrib.get('x2', '0') + ' ' + l.attrib.get('y2', '0')
     )
 
 

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -90,8 +90,13 @@ def rect2pathd(rect):
          "".format(x0, y0, x1, y1, x2, y2, x3, y3))
     return d
 
+
 def line2pathd(l):
-    return 'M' + l['x1'] + ' ' + l['y1'] + 'L' + l['x2'] + ' ' + l['y2']
+    return (
+        'M' + l.attrib['x1'] + ' ' + l.attrib['y1']
+        + 'L' + l.attrib['x2'] + ' ' + l.attrib['y2']
+    )
+
 
 def svg2paths(svg_file_location,
               return_svg_attributes=False,


### PR DESCRIPTION
`flatten_all_paths()` crashes with some SVG file in `line2pathd()`, which appears to be incorrectly implemented (attributes cannot be accessed with sub-scripting).

@mxgrey: it appears this code is from you, please comment if I'm missing something.

Edit: [here](https://cdn.discordapp.com/attachments/499297705588424715/645611959378771968/crosshatch_scribble_20191117-131012.svg) is an example of SVG which crashes