### PR TITLE
actually return svgwrite.Drawing if requested

### DIFF
--- a/svgpathtools/paths2svg.py
+++ b/svgpathtools/paths2svg.py
@@ -414,14 +414,14 @@ def wsvg(paths=None, colors=None,
           attributes=None, svg_attributes=None, svgwrite_debug=False, paths2Drawing=False):
     """Convenience function; identical to disvg() except that
     openinbrowser=False by default.  See disvg() docstring for more info."""
-    disvg(paths, colors=colors, filename=filename,
-          stroke_widths=stroke_widths, nodes=nodes,
-          node_colors=node_colors, node_radii=node_radii,
-          openinbrowser=openinbrowser, timestamp=timestamp,
-          margin_size=margin_size, mindim=mindim, dimensions=dimensions,
-          viewbox=viewbox, text=text, text_path=text_path, font_size=font_size,
-          attributes=attributes, svg_attributes=svg_attributes,
-          svgwrite_debug=svgwrite_debug, paths2Drawing=paths2Drawing)
+    return disvg(paths, colors=colors, filename=filename,
+                 stroke_widths=stroke_widths, nodes=nodes,
+                 node_colors=node_colors, node_radii=node_radii,
+                 openinbrowser=openinbrowser, timestamp=timestamp,
+                 margin_size=margin_size, mindim=mindim, dimensions=dimensions,
+                 viewbox=viewbox, text=text, text_path=text_path, font_size=font_size,
+                 attributes=attributes, svg_attributes=svg_attributes,
+                 svgwrite_debug=svgwrite_debug, paths2Drawing=paths2Drawing)
     
     
 def paths2Drawing(paths=None, colors=None,
@@ -433,11 +433,11 @@ def paths2Drawing(paths=None, colors=None,
           attributes=None, svg_attributes=None, svgwrite_debug=False, paths2Drawing=True):
     """Convenience function; identical to disvg() except that
     paths2Drawing=True by default.  See disvg() docstring for more info."""
-    disvg(paths, colors=colors, filename=filename,
-          stroke_widths=stroke_widths, nodes=nodes,
-          node_colors=node_colors, node_radii=node_radii,
-          openinbrowser=openinbrowser, timestamp=timestamp,
-          margin_size=margin_size, mindim=mindim, dimensions=dimensions,
-          viewbox=viewbox, text=text, text_path=text_path, font_size=font_size,
-          attributes=attributes, svg_attributes=svg_attributes,
-          svgwrite_debug=svgwrite_debug, paths2Drawing=paths2Drawing)
+    return disvg(paths, colors=colors, filename=filename, 
+                 stroke_widths=stroke_widths, nodes=nodes,
+                 node_colors=node_colors, node_radii=node_radii,
+                 openinbrowser=openinbrowser, timestamp=timestamp,
+                 margin_size=margin_size, mindim=mindim, dimensions=dimensions,
+                 viewbox=viewbox, text=text, text_path=text_path, font_size=font_size,
+                 attributes=attributes, svg_attributes=svg_attributes,
+                 svgwrite_debug=svgwrite_debug, paths2Drawing=paths2Drawing)


### PR DESCRIPTION
no use having the option if the wsvg and paths2Drawing entry points do not return `dwg` back from disvg