### PR TITLE
Method for checking if one path is inside another path

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+svgwrite

--- a/svgpathtools/path.py
+++ b/svgpathtools/path.py
@@ -112,7 +112,6 @@ def polygon(*points):
     return Path(*[Line(points[i], points[(i + 1) % len(points)])
                   for i in range(len(points))])
 
-
 # Conversion###################################################################
 
 def bpoints2bezier(bpoints):
@@ -2638,3 +2637,22 @@ class Path(MutableSequence):
     def scaled(self, sx, sy=None, origin=0j):
         """Scale transform.  See `scale` function for further explanation."""
         return scale(self, sx=sx, sy=sy, origin=origin)
+
+    def is_contained_by(self, other):
+        """Returns true if the path is fully contained in other closed path"""
+        assert isinstance(other, Path)
+        assert other.isclosed()
+        assert self != other
+
+        if self.intersect(other, justonemode=True):
+            return False
+
+        pt = self.point(0)
+        xmin, xmax, ymin, ymax = other.bbox()
+        pt_in_bbox = (xmin <= pt.real <= xmax) and (ymin <= pt.imag <= ymax)
+
+        if not pt_in_bbox:
+            return False
+
+        opt = complex(xmin-1, ymin-1)
+        return path_encloses_pt(pt, opt, other)

--- a/test/test_path.py
+++ b/test/test_path.py
@@ -16,7 +16,6 @@ from svgpathtools.path import _NotImplemented4ArcException
 # take too long and be too error prone. Instead the curves have been verified
 # to be correct visually with the disvg() function.
 
-
 def random_line():
     x = (random.random() - 0.5) * 2000
     y = (random.random() - 0.5) * 2000
@@ -1773,6 +1772,19 @@ class TestPathTools(unittest.TestCase):
         ccw_half_circle.append(Arc(start=(0+0j), radius=(50+50j), rotation=0, large_arc=False, sweep=True, end=(0+100j)))
         self.assertAlmostEqual(ccw_half_circle.area(), 3926.9908169872415, places=3)
         self.assertAlmostEqual(ccw_half_circle.area(chord_length=1e-3), 3926.9908169872415, places=6)
+
+    def test_is_contained_by(self):
+        enclosed_path = Path()
+        enclosed_path.append(Line((10+10j), (90+90j)))
+
+        not_enclosed_path = Path()
+        not_enclosed_path.append(Line((200+200j), (200+0j)))
+
+        enclosing_shape = Path()
+        enclosing_shape.append(Line((0+0j), (0+100j)))
+        enclosing_shape.append(Line((0+100j), (100+100j)))
+        enclosing_shape.append(Line((100+100j), (100+0j)))
+        enclosing_shape.append(Line((100+0j), (0+0j)))
 
 
 if __name__ == '__main__':

--- a/test/test_path.py
+++ b/test/test_path.py
@@ -1774,17 +1774,31 @@ class TestPathTools(unittest.TestCase):
         self.assertAlmostEqual(ccw_half_circle.area(chord_length=1e-3), 3926.9908169872415, places=6)
 
     def test_is_contained_by(self):
-        enclosed_path = Path()
-        enclosed_path.append(Line((10+10j), (90+90j)))
-
-        not_enclosed_path = Path()
-        not_enclosed_path.append(Line((200+200j), (200+0j)))
-
         enclosing_shape = Path()
         enclosing_shape.append(Line((0+0j), (0+100j)))
         enclosing_shape.append(Line((0+100j), (100+100j)))
         enclosing_shape.append(Line((100+100j), (100+0j)))
         enclosing_shape.append(Line((100+0j), (0+0j)))
+
+        enclosed_path = Path()
+        enclosed_path.append(Line((10+10j), (90+90j)))
+        self.assertTrue(enclosed_path.is_contained_by(enclosing_shape))
+
+        not_enclosed_path = Path()
+        not_enclosed_path.append(Line((200+200j), (200+0j)))
+        self.assertFalse(not_enclosed_path.is_contained_by(enclosing_shape))
+
+        intersecting_path = Path()
+        intersecting_path.append(Line((50+50j), (200+50j)))
+        self.assertFalse(intersecting_path.is_contained_by(enclosing_shape))
+
+        larger_shape = Path()
+        larger_shape.append(Line((-10-10j), (-10+110j)))
+        larger_shape.append(Line((-10+110j), (110+110j)))
+        larger_shape.append(Line((110+110j), (110+-10j)))
+        larger_shape.append(Line((110-10j), (-10-10j)))
+        self.assertFalse(larger_shape.is_contained_by(enclosing_shape))
+        self.assertTrue(enclosing_shape.is_contained_by(larger_shape))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This method can be useful on SVG files in order to determine if one figure overlaps another one, in order to perform simplification of SVG files. Also, it is an util that is required in order to compute shapes that are the intersection or the union of two shapes.