### PR TITLE
Fix Issue #99

### DIFF
--- a/svgpathtools/path.py
+++ b/svgpathtools/path.py
@@ -2941,6 +2941,7 @@ class Path(MutableSequence):
                 if command is None:
                     raise ValueError("Unallowed implicit command in %s, position %s" % (
                         pathdef, len(pathdef.split()) - len(elements)))
+                last_command = command  # Used by S and T
 
             if command == 'M':
                 # Moveto command.

--- a/test/test_parsing.py
+++ b/test/test_parsing.py
@@ -277,3 +277,11 @@ class TestParser(unittest.TestCase):
         path1 = parse_path("m 100 100 L 300 100 L 200 300 z", 50 + 50j)
         path2 = Path("m 100 100 L 300 100 L 200 300 z", 50 + 50j)
         self.assertEqual(path1, path2)
+
+    def test_issue_99(self):
+        p = Path("M  100 250    S  200 200   200 250     300 300   300 250")
+        self.assertEqual(p.d(useSandT=True), 'M 100.0,250.0 S 200.0,200.0 200.0,250.0 S 300.0,300.0 300.0,250.0')
+        self.assertEqual(p.d(),
+                         'M 100.0,250.0 C 100.0,250.0 200.0,200.0 200.0,250.0 C 200.0,300.0 300.0,300.0 300.0,250.0')
+        self.assertNotEqual(p.d(),
+                         'M 100.0,250.0 C 100.0,250.0 200.0,200.0 200.0,250.0 C 200.0,250.0 300.0,300.0 300.0,250.0')


### PR DESCRIPTION
Issue #99 is caused when compound S commands fail to set the last_command to `S`. If an S command contains more than one S. The behavior of the smooth curve changes. The first `S` command is coincident with the current point. However, the second `S` command is the reflection of the previous control point. The current state of the code only updates the last_command when we change command, which means last_command remains set to `M` and the behavior remains set to coincident to the current point.

This is also corrected in regebro/svg.path#17 and the source is merely modified to reflect the current state of the `svg.path` parser (Close and Move pathsegments notwithstanding).

Test coverage is added to prove the functionality of this correction.