### PR TITLE
Fixed crash with inconsistent yet valid paths

### DIFF
--- a/svgpathtools/path.py
+++ b/svgpathtools/path.py
@@ -2967,7 +2967,7 @@ class Path(MutableSequence):
                 # Close path
                 if not (current_pos == start_pos):
                     segments.append(Line(current_pos, start_pos))
-                self.closed = True
+                    self.closed = True
                 current_pos = start_pos
                 command = None
 
@@ -3077,8 +3077,10 @@ class Path(MutableSequence):
 
                 if not absolute:
                     end += current_pos
-
-                segments.append(Arc(current_pos, radius, rotation, arc, sweep, end))
+                if abs(radius.real) > 0 and abs(radius.imag) > 0:
+                    segments.append(Arc(current_pos, radius, rotation, arc, sweep, end))
+                else:
+                    segments.append(Line(current_pos, end))
                 current_pos = end
 
         return segments


### PR DESCRIPTION
`Path._parse_path()` currently crashes when it encounters inconsistent, yet valid path commands, such as:

- arcs with 0 radius: `<path d="M1.77,1.77 a 0.000 0.000 0 1 0 0.001 0Z"/>`
- Z command in empty path: `<path d="M2642.4187716490305,3635.0795848199714 Z"/>`

Although such SVG shouldn't be generated, they are not an uncommon sight in procedurally generated files. The above examples actually are real world example (related bugs: abey79/vpype#58, abey79/vpype#59).

This fix avoids setting `self.closed=True` with such spurious path commands and uses a `Line` instead of an `Arc` if either of the radii is 0 (consistently with how macOS/Safari/Chrome handles such issue).