### PR TITLE
Process path within an explicit SVG namespace

### DIFF
--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -153,7 +153,7 @@ def svg2paths(svg_file_location,
         return dict(list(zip(keys, values)))
 
     # Use minidom to extract path strings from input SVG
-    paths = [dom2dict(el) for el in doc.getElementsByTagName('path')]
+    paths = [dom2dict(el) for el in doc.getElementsByTagNameNS('http://www.w3.org/2000/svg', 'path')]
     d_strings = [el['d'] for el in paths]
     attribute_dictionary_list = paths
 

--- a/test/namespaces.svg
+++ b/test/namespaces.svg
@@ -1,0 +1,7 @@
+<svg>
+  <g xmlns:ns0="http://www.inkscape.org/namespaces/inkscape" ns0:label="Hershey Text" style="stroke:#000000;fill:none;stroke-linecap:round;stroke-linejoin:round" transform="">
+    <g id="a" transform="translate(0.0000000,0.0000000)">
+      <ns1:path xmlns:ns1="http://www.w3.org/2000/svg" d="M 630 567 L 567 630 L 472 662 L 346 662 L 252 630 L 189 567 L 189 504 L 220 441 L 252 410 L 315 378 L 504 315 L 567 284 L 598 252 L 630 189 L 630 94.5 L 567 31.5 L 472 0 L 346 0 L 252 31.5 L 189 94.5" transform="translate(-2.7,13)scale(0.018898, -0.018898)" style="stroke-width:1.000in" id="aa"/>
+    </g>
+  </g>
+</svg>

--- a/test/test_svg2paths.py
+++ b/test/test_svg2paths.py
@@ -50,3 +50,12 @@ class TestSVG2Paths(unittest.TestCase):
         self.assertTrue(len(path_circle)==2)
         self.assertTrue(path_circle==path_circle_correct)
         self.assertTrue(path_circle.isclosed())
+
+    def test_svg2paths_namespaces(self):
+
+        paths, _ = svg2paths(join(dirname(__file__), 'namespaces.svg'))
+        self.assertTrue(len(paths)==1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi, first thanks a lot, your package is really fast and useful.

I am using an @evil-mad tool to generate paths from text and `path` nodes are generated with an explicit SVG namespace. (cf test file).

I only fixed the path collection as I am not aware of performance implication but I can all of the `getElementsByTagName(a)` by `getElementsByTagNameNS('http://www.w3.org/2000/svg', a)` if you prefer.