### PR TITLE
add support for units and handle mindim=None correctly.

### DIFF
--- a/svgpathtools/paths2svg.py
+++ b/svgpathtools/paths2svg.py
@@ -97,7 +97,7 @@ def big_bounding_box(paths_n_stuff):
 def disvg(paths=None, colors=None, filename=None, stroke_widths=None,
           nodes=None, node_colors=None, node_radii=None,
           openinbrowser=True, timestamp=None, margin_size=0.1,
-          mindim=600, dimensions=None, viewbox=None, text=None,
+          mindim=600, dimensions=None, baseunit='px', viewbox=None, text=None,
           text_path=None, font_size=None, attributes=None,
           svg_attributes=None, svgwrite_debug=False,
           paths2Drawing=False):
@@ -313,12 +313,16 @@ def disvg(paths=None, colors=None, filename=None, stroke_widths=None,
         dy += 2*margin_size*dy + extra_space_for_style
         viewbox = "%s %s %s %s" % (xmin, ymin, dx, dy)
 
-        if dx > dy:
-            szx = str(mindim) + 'px'
-            szy = str(int(ceil(mindim * dy / dx))) + 'px'
+        if mindim is None:
+            szx = "{}{}".format(dx, baseunit)
+            szy = "{}{}".format(dy, baseunit)
         else:
-            szx = str(int(ceil(mindim * dx / dy))) + 'px'
-            szy = str(mindim) + 'px'
+            if dx > dy:
+                szx = str(mindim) + baseunit
+                szy = str(int(ceil(mindim * dy / dx))) + baseunit
+            else:
+                szx = str(int(ceil(mindim * dx / dy))) + baseunit
+                szy = str(mindim) + baseunit 
         dimensions = szx, szy
 
     # Create an SVG file
@@ -425,7 +429,7 @@ def disvg(paths=None, colors=None, filename=None, stroke_widths=None,
 def wsvg(paths=None, colors=None, filename=None, stroke_widths=None,
          nodes=None, node_colors=None, node_radii=None,
          openinbrowser=False, timestamp=False, margin_size=0.1,
-         mindim=600, dimensions=None, viewbox=None, text=None,
+         mindim=600, dimensions=None, baseunit='px', viewbox=None, text=None,
          text_path=None, font_size=None, attributes=None,
          svg_attributes=None, svgwrite_debug=False,
          paths2Drawing=False):
@@ -443,7 +447,7 @@ def wsvg(paths=None, colors=None, filename=None, stroke_widths=None,
                  node_colors=node_colors, node_radii=node_radii,
                  openinbrowser=openinbrowser, timestamp=timestamp,
                  margin_size=margin_size, mindim=mindim,
-                 dimensions=dimensions, viewbox=viewbox, text=text,
+                 dimensions=dimensions, baseunit=baseunit, viewbox=viewbox, text=text,
                  text_path=text_path, font_size=font_size,
                  attributes=attributes, svg_attributes=svg_attributes,
                  svgwrite_debug=svgwrite_debug,
@@ -453,7 +457,7 @@ def wsvg(paths=None, colors=None, filename=None, stroke_widths=None,
 def paths2Drawing(paths=None, colors=None, filename=None,
                   stroke_widths=None, nodes=None, node_colors=None,
                   node_radii=None, openinbrowser=False, timestamp=False,
-                  margin_size=0.1, mindim=600, dimensions=None,
+                  margin_size=0.1, mindim=600, dimensions=None, baseunit='px',
                   viewbox=None, text=None, text_path=None,
                   font_size=None, attributes=None, svg_attributes=None,
                   svgwrite_debug=False, paths2Drawing=True):
@@ -470,7 +474,7 @@ def paths2Drawing(paths=None, colors=None, filename=None,
                  node_colors=node_colors, node_radii=node_radii,
                  openinbrowser=openinbrowser, timestamp=timestamp,
                  margin_size=margin_size, mindim=mindim,
-                 dimensions=dimensions, viewbox=viewbox, text=text,
+                 dimensions=dimensions, baseunit=baseunit, viewbox=viewbox, text=text,
                  text_path=text_path, font_size=font_size,
                  attributes=attributes, svg_attributes=svg_attributes,
                  svgwrite_debug=svgwrite_debug,

--- a/svgpathtools/paths2svg.py
+++ b/svgpathtools/paths2svg.py
@@ -97,10 +97,10 @@ def big_bounding_box(paths_n_stuff):
 def disvg(paths=None, colors=None, filename=None, stroke_widths=None,
           nodes=None, node_colors=None, node_radii=None,
           openinbrowser=True, timestamp=None, margin_size=0.1,
-          mindim=600, dimensions=None, baseunit='px', viewbox=None, text=None,
+          mindim=600, dimensions=None, viewbox=None, text=None,
           text_path=None, font_size=None, attributes=None,
           svg_attributes=None, svgwrite_debug=False,
-          paths2Drawing=False):
+          paths2Drawing=False, baseunit='px'):
     """Creates (and optionally displays) an SVG file.
 
     REQUIRED INPUTS:
@@ -429,10 +429,10 @@ def disvg(paths=None, colors=None, filename=None, stroke_widths=None,
 def wsvg(paths=None, colors=None, filename=None, stroke_widths=None,
          nodes=None, node_colors=None, node_radii=None,
          openinbrowser=False, timestamp=False, margin_size=0.1,
-         mindim=600, dimensions=None, baseunit='px', viewbox=None, text=None,
+         mindim=600, dimensions=None, viewbox=None, text=None,
          text_path=None, font_size=None, attributes=None,
          svg_attributes=None, svgwrite_debug=False,
-         paths2Drawing=False):
+         paths2Drawing=False, baseunit='px'):
     """Create SVG and write to disk.
 
     Note: This is identical to `disvg()` except that `openinbrowser`
@@ -447,20 +447,20 @@ def wsvg(paths=None, colors=None, filename=None, stroke_widths=None,
                  node_colors=node_colors, node_radii=node_radii,
                  openinbrowser=openinbrowser, timestamp=timestamp,
                  margin_size=margin_size, mindim=mindim,
-                 dimensions=dimensions, baseunit=baseunit, viewbox=viewbox, text=text,
+                 dimensions=dimensions, viewbox=viewbox, text=text,
                  text_path=text_path, font_size=font_size,
                  attributes=attributes, svg_attributes=svg_attributes,
                  svgwrite_debug=svgwrite_debug,
-                 paths2Drawing=paths2Drawing)
+                 paths2Drawing=paths2Drawing, baseunit=baseunit)
     
     
 def paths2Drawing(paths=None, colors=None, filename=None,
                   stroke_widths=None, nodes=None, node_colors=None,
                   node_radii=None, openinbrowser=False, timestamp=False,
-                  margin_size=0.1, mindim=600, dimensions=None, baseunit='px',
+                  margin_size=0.1, mindim=600, dimensions=None,
                   viewbox=None, text=None, text_path=None,
                   font_size=None, attributes=None, svg_attributes=None,
-                  svgwrite_debug=False, paths2Drawing=True):
+                  svgwrite_debug=False, paths2Drawing=True, baseunit='px'):
     """Create and return `svg.Drawing` object.
 
     Note: This is identical to `disvg()` except that `paths2Drawing`
@@ -474,8 +474,8 @@ def paths2Drawing(paths=None, colors=None, filename=None,
                  node_colors=node_colors, node_radii=node_radii,
                  openinbrowser=openinbrowser, timestamp=timestamp,
                  margin_size=margin_size, mindim=mindim,
-                 dimensions=dimensions, baseunit=baseunit, viewbox=viewbox, text=text,
+                 dimensions=dimensions, viewbox=viewbox, text=text,
                  text_path=text_path, font_size=font_size,
                  attributes=attributes, svg_attributes=svg_attributes,
                  svgwrite_debug=svgwrite_debug,
-                 paths2Drawing=paths2Drawing)
+                 paths2Drawing=paths2Drawing, baseunit=baseunit)


### PR DESCRIPTION
This PR adds support for real-world units in generated svg files (useful for generating CNC inputs, for example).  It also fixes a bug where mindim=None crashes, rather than unconstraining the viewport size as you would expect.