### PR TITLE
Support reading of SVGs from strings and file-like objects

### DIFF
--- a/svgpathtools/__init__.py
+++ b/svgpathtools/__init__.py
@@ -17,6 +17,6 @@ from .document import (Document, CONVERSIONS, CONVERT_ONLY_PATHS,
 from .svg_io_sax import SaxDocument
 
 try:
-    from .svg_to_paths import svg2paths, svg2paths2
+    from .svg_to_paths import svg2paths, svg2paths2, svg_string2paths, svg_string2paths2
 except ImportError:
     pass

--- a/svgpathtools/__init__.py
+++ b/svgpathtools/__init__.py
@@ -17,6 +17,6 @@ from .document import (Document, CONVERSIONS, CONVERT_ONLY_PATHS,
 from .svg_io_sax import SaxDocument
 
 try:
-    from .svg_to_paths import svg2paths, svg2paths2, svg_string2paths, svg_string2paths2
+    from .svg_to_paths import svg2paths, svg2paths2, svgstr2paths
 except ImportError:
     pass

--- a/svgpathtools/document.py
+++ b/svgpathtools/document.py
@@ -41,6 +41,7 @@ import xml.etree.ElementTree as etree
 from xml.etree.ElementTree import Element, SubElement, register_namespace
 from xml.dom.minidom import parseString
 import warnings
+from io import StringIO
 from tempfile import gettempdir
 from time import time
 
@@ -256,6 +257,18 @@ class Document:
             self.tree = etree.parse(svg_file_name_or_file)
 
         self.root = self.tree.getroot()
+
+    @staticmethod
+    def from_svg_string(svg_string):
+        """Factory method for creating a document from a string holding a svg
+        object
+        """
+        # wrap string into StringIO object
+        svg_file_obj = StringIO(svg_string)
+        # reset cursor to the beginning of the buffer
+        svg_file_obj.seek(0)
+        # create document from file object
+        return Document(svg_file_obj)
 
     def paths(self, group_filter=lambda x: True,
               path_filter=lambda x: True, path_conversions=CONVERSIONS):

--- a/svgpathtools/document.py
+++ b/svgpathtools/document.py
@@ -224,7 +224,7 @@ def flattened_paths_from_group(group_to_flatten, root, recursive=True,
 
 
 class Document:
-    def __init__(self, filepath=None):
+    def __init__(self, svg_file_name_or_file=None):
         """A container for a DOM-style SVG document.
 
         The `Document` class provides a simple interface to modify and analyze 
@@ -235,19 +235,25 @@ class Document:
         The output Path objects will be transformed based on their parent groups.
         
         Args:
-            filepath (str): The filepath of the DOM-style object.
+            svg_file_name_or_file (str or file-like): The filepath of the
+                DOM-style object or a file-like object containing it.
         """
+        self.original_filepath = None
 
-        # remember location of original svg file
-        self.original_filepath = filepath
-        if filepath is not None and os.path.dirname(filepath) == '':
-            self.original_filepath = os.path.join(os.getcwd(), filepath)
+        # strings are interpreted as file location everything else is treated as
+        # file-like object and passed to the xml parser directly
+        if isinstance(svg_file_name_or_file, str):
+            # remember location of original svg file if any
+            self.original_filepath = svg_file_name_or_file
+            if os.path.dirname(svg_file_name_or_file) == '':
+                self.original_filepath = os.path.join(
+                    os.getcwd(), svg_file_name_or_file)
 
-        if filepath is None:
+        if svg_file_name_or_file is None:
             self.tree = etree.ElementTree(Element('svg'))
         else:
             # parse svg to ElementTree object
-            self.tree = etree.parse(filepath)
+            self.tree = etree.parse(svg_file_name_or_file)
 
         self.root = self.tree.getroot()
 

--- a/svgpathtools/document.py
+++ b/svgpathtools/document.py
@@ -265,8 +265,6 @@ class Document:
         """
         # wrap string into StringIO object
         svg_file_obj = StringIO(svg_string)
-        # reset cursor to the beginning of the buffer
-        svg_file_obj.seek(0)
         # create document from file object
         return Document(svg_file_obj)
 

--- a/svgpathtools/document.py
+++ b/svgpathtools/document.py
@@ -258,8 +258,8 @@ class Document:
 
         self.root = self.tree.getroot()
 
-    @staticmethod
-    def from_svg_string(svg_string):
+    @classmethod
+    def from_svg_string(cls, svg_string):
         """Factory method for creating a document from a string holding a svg
         object
         """

--- a/svgpathtools/document.py
+++ b/svgpathtools/document.py
@@ -225,7 +225,7 @@ def flattened_paths_from_group(group_to_flatten, root, recursive=True,
 
 
 class Document:
-    def __init__(self, svg_file_name_or_file=None):
+    def __init__(self, filepath=None):
         """A container for a DOM-style SVG document.
 
         The `Document` class provides a simple interface to modify and analyze 
@@ -236,25 +236,25 @@ class Document:
         The output Path objects will be transformed based on their parent groups.
         
         Args:
-            svg_file_name_or_file (str or file-like): The filepath of the
+            filepath (str or file-like): The filepath of the
                 DOM-style object or a file-like object containing it.
         """
         self.original_filepath = None
 
         # strings are interpreted as file location everything else is treated as
         # file-like object and passed to the xml parser directly
-        if isinstance(svg_file_name_or_file, str):
+        if isinstance(filepath, str):
             # remember location of original svg file if any
-            self.original_filepath = svg_file_name_or_file
-            if os.path.dirname(svg_file_name_or_file) == '':
+            self.original_filepath = filepath
+            if os.path.dirname(filepath) == '':
                 self.original_filepath = os.path.join(
-                    os.getcwd(), svg_file_name_or_file)
+                    os.getcwd(), filepath)
 
-        if svg_file_name_or_file is None:
+        if filepath is None:
             self.tree = etree.ElementTree(Element('svg'))
         else:
             # parse svg to ElementTree object
-            self.tree = etree.parse(svg_file_name_or_file)
+            self.tree = etree.parse(filepath)
 
         self.root = self.tree.getroot()
 

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -129,7 +129,7 @@ def line2pathd(l):
     )
 
 
-def svg2paths(svg_file_location,
+def svg2paths(svg_file_name_or_file,
               return_svg_attributes=False,
               convert_circles_to_paths=True,
               convert_ellipses_to_paths=True,
@@ -144,7 +144,9 @@ def svg2paths(svg_file_location,
     SVG Path, Line, Polyline, Polygon, Circle, and Ellipse elements.
 
     Args:
-        svg_file_location (string): the location of the svg file
+        svg_file_name_or_file (string or file-like object): the location of the
+            svg file on disk or a file-like object containing the content of a
+            svg file
         return_svg_attributes (bool): Set to True and a dictionary of
             svg-attributes will be extracted and returned.  See also the 
             `svg2paths2()` function.
@@ -168,10 +170,14 @@ def svg2paths(svg_file_location,
         list: The list of corresponding path attribute dictionaries.
         dict (optional): A dictionary of svg-attributes (see `svg2paths2()`).
     """
-    if os_path.dirname(svg_file_location) == '':
-        svg_file_location = os_path.join(getcwd(), svg_file_location)
+    # strings are interpreted as file location everything else is treated as
+    # file-like object and passed to the xml parser directly
+    if isinstance(svg_file_name_or_file, str):
+        if os_path.dirname(svg_file_name_or_file) == '':
+            svg_file_name_or_file = os_path.join(
+                getcwd(), svg_file_name_or_file)
 
-    doc = parse(svg_file_location)
+    doc = parse(svg_file_name_or_file)
 
     def dom2dict(element):
         """Converts DOM elements to dictionaries of attributes."""
@@ -230,7 +236,7 @@ def svg2paths(svg_file_location,
         return path_list, attribute_dictionary_list
 
 
-def svg2paths2(svg_file_location,
+def svg2paths2(svg_file_name_or_file,
                return_svg_attributes=True,
                convert_circles_to_paths=True,
                convert_ellipses_to_paths=True,
@@ -241,7 +247,7 @@ def svg2paths2(svg_file_location,
     """Convenience function; identical to svg2paths() except that
     return_svg_attributes=True by default.  See svg2paths() docstring for more
     info."""
-    return svg2paths(svg_file_location=svg_file_location,
+    return svg2paths(svg_file_name_or_file=svg_file_name_or_file,
                      return_svg_attributes=return_svg_attributes,
                      convert_circles_to_paths=convert_circles_to_paths,
                      convert_ellipses_to_paths=convert_ellipses_to_paths,

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -130,7 +130,7 @@ def line2pathd(l):
     )
 
 
-def svg2paths(svg_file_name_or_file,
+def svg2paths(svg_file_location,
               return_svg_attributes=False,
               convert_circles_to_paths=True,
               convert_ellipses_to_paths=True,
@@ -145,7 +145,7 @@ def svg2paths(svg_file_name_or_file,
     SVG Path, Line, Polyline, Polygon, Circle, and Ellipse elements.
 
     Args:
-        svg_file_name_or_file (string or file-like object): the location of the
+        svg_file_location (string or file-like object): the location of the
             svg file on disk or a file-like object containing the content of a
             svg file
         return_svg_attributes (bool): Set to True and a dictionary of
@@ -173,12 +173,12 @@ def svg2paths(svg_file_name_or_file,
     """
     # strings are interpreted as file location everything else is treated as
     # file-like object and passed to the xml parser directly
-    if isinstance(svg_file_name_or_file, str):
-        if os_path.dirname(svg_file_name_or_file) == '':
-            svg_file_name_or_file = os_path.join(
-                getcwd(), svg_file_name_or_file)
+    if isinstance(svg_file_location, str):
+        if os_path.dirname(svg_file_location) == '':
+            svg_file_location = os_path.join(
+                getcwd(), svg_file_location)
 
-    doc = parse(svg_file_name_or_file)
+    doc = parse(svg_file_location)
 
     def dom2dict(element):
         """Converts DOM elements to dictionaries of attributes."""
@@ -237,7 +237,7 @@ def svg2paths(svg_file_name_or_file,
         return path_list, attribute_dictionary_list
 
 
-def svg2paths2(svg_file_name_or_file,
+def svg2paths2(svg_file_location,
                return_svg_attributes=True,
                convert_circles_to_paths=True,
                convert_ellipses_to_paths=True,
@@ -248,7 +248,7 @@ def svg2paths2(svg_file_name_or_file,
     """Convenience function; identical to svg2paths() except that
     return_svg_attributes=True by default.  See svg2paths() docstring for more
     info."""
-    return svg2paths(svg_file_name_or_file=svg_file_name_or_file,
+    return svg2paths(svg_file_location=svg_file_location,
                      return_svg_attributes=return_svg_attributes,
                      convert_circles_to_paths=convert_circles_to_paths,
                      convert_ellipses_to_paths=convert_ellipses_to_paths,
@@ -271,7 +271,7 @@ def svg_string2paths(svg_string,
     info."""
     # wrap string into StringIO object
     svg_file_obj = StringIO(svg_string)
-    return svg2paths(svg_file_name_or_file=svg_file_obj,
+    return svg2paths(svg_file_location=svg_file_obj,
                      return_svg_attributes=return_svg_attributes,
                      convert_circles_to_paths=convert_circles_to_paths,
                      convert_ellipses_to_paths=convert_ellipses_to_paths,

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -258,7 +258,7 @@ def svg2paths2(svg_file_location,
                      convert_rectangles_to_paths=convert_rectangles_to_paths)
 
 
-def svg_string2paths(svg_string,
+def svgstr2paths(svg_string,
                return_svg_attributes=False,
                convert_circles_to_paths=True,
                convert_ellipses_to_paths=True,

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -5,6 +5,7 @@ The main tool being the svg2paths() function."""
 from __future__ import division, absolute_import, print_function
 from xml.dom.minidom import parse
 from os import path as os_path, getcwd
+from io import StringIO
 import re
 
 # Internal dependencies
@@ -248,6 +249,52 @@ def svg2paths2(svg_file_name_or_file,
     return_svg_attributes=True by default.  See svg2paths() docstring for more
     info."""
     return svg2paths(svg_file_name_or_file=svg_file_name_or_file,
+                     return_svg_attributes=return_svg_attributes,
+                     convert_circles_to_paths=convert_circles_to_paths,
+                     convert_ellipses_to_paths=convert_ellipses_to_paths,
+                     convert_lines_to_paths=convert_lines_to_paths,
+                     convert_polylines_to_paths=convert_polylines_to_paths,
+                     convert_polygons_to_paths=convert_polygons_to_paths,
+                     convert_rectangles_to_paths=convert_rectangles_to_paths)
+
+
+def svg_string2paths(svg_string,
+               return_svg_attributes=False,
+               convert_circles_to_paths=True,
+               convert_ellipses_to_paths=True,
+               convert_lines_to_paths=True,
+               convert_polylines_to_paths=True,
+               convert_polygons_to_paths=True,
+               convert_rectangles_to_paths=True):
+    """Convenience function; identical to svg2paths() except that it takes the
+    svg object as string.  See svg2paths() docstring for more
+    info."""
+    # wrap string into StringIO object
+    svg_file_obj = StringIO(svg_string)
+    # reset cursor to the beginning of the buffer
+    svg_file_obj.seek(0)
+    return svg2paths(svg_file_name_or_file=svg_file_obj,
+                     return_svg_attributes=return_svg_attributes,
+                     convert_circles_to_paths=convert_circles_to_paths,
+                     convert_ellipses_to_paths=convert_ellipses_to_paths,
+                     convert_lines_to_paths=convert_lines_to_paths,
+                     convert_polylines_to_paths=convert_polylines_to_paths,
+                     convert_polygons_to_paths=convert_polygons_to_paths,
+                     convert_rectangles_to_paths=convert_rectangles_to_paths)
+
+
+def svg_string2paths2(svg_string,
+               return_svg_attributes=True,
+               convert_circles_to_paths=True,
+               convert_ellipses_to_paths=True,
+               convert_lines_to_paths=True,
+               convert_polylines_to_paths=True,
+               convert_polygons_to_paths=True,
+               convert_rectangles_to_paths=True):
+    """Convenience function; identical to svg2paths2() except that it takes the
+    svg object as string.  See svg2paths() docstring for more
+    info."""
+    return svg_string2paths(svg_string=svg_string,
                      return_svg_attributes=return_svg_attributes,
                      convert_circles_to_paths=convert_circles_to_paths,
                      convert_ellipses_to_paths=convert_ellipses_to_paths,

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -279,24 +279,3 @@ def svg_string2paths(svg_string,
                      convert_polylines_to_paths=convert_polylines_to_paths,
                      convert_polygons_to_paths=convert_polygons_to_paths,
                      convert_rectangles_to_paths=convert_rectangles_to_paths)
-
-
-def svg_string2paths2(svg_string,
-               return_svg_attributes=True,
-               convert_circles_to_paths=True,
-               convert_ellipses_to_paths=True,
-               convert_lines_to_paths=True,
-               convert_polylines_to_paths=True,
-               convert_polygons_to_paths=True,
-               convert_rectangles_to_paths=True):
-    """Convenience function; identical to svg2paths2() except that it takes the
-    svg object as string.  See svg2paths() docstring for more
-    info."""
-    return svg_string2paths(svg_string=svg_string,
-                     return_svg_attributes=return_svg_attributes,
-                     convert_circles_to_paths=convert_circles_to_paths,
-                     convert_ellipses_to_paths=convert_ellipses_to_paths,
-                     convert_lines_to_paths=convert_lines_to_paths,
-                     convert_polylines_to_paths=convert_polylines_to_paths,
-                     convert_polygons_to_paths=convert_polygons_to_paths,
-                     convert_rectangles_to_paths=convert_rectangles_to_paths)

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -271,8 +271,6 @@ def svg_string2paths(svg_string,
     info."""
     # wrap string into StringIO object
     svg_file_obj = StringIO(svg_string)
-    # reset cursor to the beginning of the buffer
-    svg_file_obj.seek(0)
     return svg2paths(svg_file_name_or_file=svg_file_obj,
                      return_svg_attributes=return_svg_attributes,
                      convert_circles_to_paths=convert_circles_to_paths,

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -26,11 +26,7 @@ class TestDocument(unittest.TestCase):
             # read entire file into string
             file_content = file.read()
             # prepare stringio object
-            file_as_stringio = StringIO()
-            # paste file content into it
-            file_as_stringio.write(file_content)
-            # reset curser to its beginning
-            file_as_stringio.seek(0)
+            file_as_stringio = StringIO(file_content)
 
             doc = Document(file_as_stringio)
 

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -1,0 +1,45 @@
+from __future__ import division, absolute_import, print_function
+import unittest
+from svgpathtools import *
+from io import StringIO
+from os.path import join, dirname
+
+class TestDocument(unittest.TestCase):
+    def test_from_file_path(self):
+        """ Test reading svg from file provided as path """
+        doc = Document(join(dirname(__file__), 'polygons.svg'))
+
+        self.assertEqual(len(doc.paths()), 2)
+
+    def test_from_file_object(self):
+        """ Test reading svg from file object that has already been opened """
+        with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
+            doc = Document(file)
+
+            self.assertEqual(len(doc.paths()), 2)
+
+    def test_from_stringio(self):
+        """ Test reading svg object contained in a StringIO object """
+        with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
+            # read entire file into string
+            file_content: str = file.read()
+            # prepare stringio object
+            file_as_stringio = StringIO()
+            # paste file content into it
+            file_as_stringio.write(file_content)
+            # reset curser to its beginning
+            file_as_stringio.seek(0)
+
+            doc = Document(file_as_stringio)
+
+            self.assertEqual(len(doc.paths()), 2)
+
+    def test_from_string_without_svg_attrs(self):
+        """ Test reading svg object contained in a string without svg attributes"""
+        with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
+            # read entire file into string
+            file_content: str = file.read()
+
+            doc = Document.from_svg_string(file_content)
+
+            self.assertEqual(len(doc.paths()), 2)

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -2,6 +2,7 @@ from __future__ import division, absolute_import, print_function
 import unittest
 from svgpathtools import *
 from io import StringIO
+from io import open # overrides build-in open for compatibility with python2
 from os.path import join, dirname
 
 class TestDocument(unittest.TestCase):
@@ -20,7 +21,8 @@ class TestDocument(unittest.TestCase):
 
     def test_from_stringio(self):
         """ Test reading svg object contained in a StringIO object """
-        with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
+        with open(join(dirname(__file__), 'polygons.svg'),
+                  'r', encoding='utf-8') as file:
             # read entire file into string
             file_content = file.read()
             # prepare stringio object
@@ -34,9 +36,10 @@ class TestDocument(unittest.TestCase):
 
             self.assertEqual(len(doc.paths()), 2)
 
-    def test_from_string_without_svg_attrs(self):
-        """ Test reading svg object contained in a string without svg attributes"""
-        with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
+    def test_from_string(self):
+        """ Test reading svg object contained in a string"""
+        with open(join(dirname(__file__), 'polygons.svg'),
+                  'r', encoding='utf-8') as file:
             # read entire file into string
             file_content = file.read()
 

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -22,7 +22,7 @@ class TestDocument(unittest.TestCase):
         """ Test reading svg object contained in a StringIO object """
         with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
             # read entire file into string
-            file_content: str = file.read()
+            file_content = file.read()
             # prepare stringio object
             file_as_stringio = StringIO()
             # paste file content into it
@@ -38,7 +38,7 @@ class TestDocument(unittest.TestCase):
         """ Test reading svg object contained in a string without svg attributes"""
         with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
             # read entire file into string
-            file_content: str = file.read()
+            file_content = file.read()
 
             doc = Document.from_svg_string(file_content)
 

--- a/test/test_svg2paths.py
+++ b/test/test_svg2paths.py
@@ -87,24 +87,13 @@ class TestSVG2Paths(unittest.TestCase):
 
             self.assertEqual(len(paths), 2)
 
-    def test_from_string_without_svg_attrs(self):
-        """ Test reading svg object contained in a string without svg attributes"""
+    def test_from_string(self):
+        """ Test reading svg object contained in a string """
         with open(join(dirname(__file__), 'polygons.svg'),
                   'r', encoding='utf-8') as file:
             # read entire file into string
             file_content = file.read()
 
             paths, _ = svg_string2paths(file_content)
-
-            self.assertEqual(len(paths), 2)
-
-    def test_from_string_with_svg_attrs(self):
-        """ Test reading svg object contained in a string with svg attributes"""
-        with open(join(dirname(__file__), 'polygons.svg'),
-                  'r', encoding='utf-8') as file:
-            # read entire file into string
-            file_content = file.read()
-
-            paths, _, _ = svg_string2paths2(file_content)
 
             self.assertEqual(len(paths), 2)

--- a/test/test_svg2paths.py
+++ b/test/test_svg2paths.py
@@ -2,6 +2,7 @@ from __future__ import division, absolute_import, print_function
 import unittest
 from svgpathtools import *
 from io import StringIO
+from io import open # overrides build-in open for compatibility with python2
 from os.path import join, dirname
 
 from svgpathtools.svg_to_paths import rect2pathd
@@ -75,7 +76,8 @@ class TestSVG2Paths(unittest.TestCase):
 
     def test_from_stringio(self):
         """ Test reading svg object contained in a StringIO object """
-        with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
+        with open(join(dirname(__file__), 'polygons.svg'),
+                  'r', encoding='utf-8') as file:
             # read entire file into string
             file_content = file.read()
             # prepare stringio object
@@ -91,7 +93,8 @@ class TestSVG2Paths(unittest.TestCase):
 
     def test_from_string_without_svg_attrs(self):
         """ Test reading svg object contained in a string without svg attributes"""
-        with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
+        with open(join(dirname(__file__), 'polygons.svg'),
+                  'r', encoding='utf-8') as file:
             # read entire file into string
             file_content = file.read()
 
@@ -101,7 +104,8 @@ class TestSVG2Paths(unittest.TestCase):
 
     def test_from_string_with_svg_attrs(self):
         """ Test reading svg object contained in a string with svg attributes"""
-        with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
+        with open(join(dirname(__file__), 'polygons.svg'),
+                  'r', encoding='utf-8') as file:
             # read entire file into string
             file_content = file.read()
 

--- a/test/test_svg2paths.py
+++ b/test/test_svg2paths.py
@@ -94,6 +94,6 @@ class TestSVG2Paths(unittest.TestCase):
             # read entire file into string
             file_content = file.read()
 
-            paths, _ = svg_string2paths(file_content)
+            paths, _ = svgstr2paths(file_content)
 
             self.assertEqual(len(paths), 2)

--- a/test/test_svg2paths.py
+++ b/test/test_svg2paths.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import, print_function
 import unittest
 from svgpathtools import *
+from io import StringIO
 from os.path import join, dirname
 
 from svgpathtools.svg_to_paths import rect2pathd
@@ -58,3 +59,32 @@ class TestSVG2Paths(unittest.TestCase):
         self.assertEqual(rect2pathd(non_rounded), 'M10.0 10.0 L 110.0 10.0 L 110.0 110.0 L 10.0 110.0 z')
         rounded = {"x":"10", "y":"10", "width":"100","height":"100", "rx":"15", "ry": "12"}
         self.assertEqual(rect2pathd(rounded), "M 25.0 10.0 L 95.0 10.0 A 15.0 12.0 0 0 1 110.0 22.0 L 110.0 98.0 A 15.0 12.0 0 0 1 95.0 110.0 L 25.0 110.0 A 15.0 12.0 0 0 1 10.0 98.0 L 10.0 22.0 A 15.0 12.0 0 0 1 25.0 10.0 z")
+
+    def test_from_file_path(self):
+        """ Test reading svg from file provided as path """
+        paths, _ = svg2paths(join(dirname(__file__), 'polygons.svg'))
+
+        self.assertEqual(len(paths), 2)
+
+    def test_from_file_object(self):
+        """ Test reading svg from file object that has already been opened """
+        with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
+            paths, _ = svg2paths(file)
+
+            self.assertEqual(len(paths), 2)
+
+    def test_from_stringio(self):
+        """ Test reading svg object contained in an StringIO object """
+        with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
+            # read entire file into string
+            file_content: str = file.read()
+            # prepare stringio object
+            file_as_stringio = StringIO()
+            # paste file content into it
+            file_as_stringio.write(file_content)
+            # reset curser to its beginning
+            file_as_stringio.seek(0)
+
+            paths, _ = svg2paths(file_as_stringio)
+
+            self.assertEqual(len(paths), 2)

--- a/test/test_svg2paths.py
+++ b/test/test_svg2paths.py
@@ -77,7 +77,7 @@ class TestSVG2Paths(unittest.TestCase):
         """ Test reading svg object contained in a StringIO object """
         with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
             # read entire file into string
-            file_content: str = file.read()
+            file_content = file.read()
             # prepare stringio object
             file_as_stringio = StringIO()
             # paste file content into it
@@ -93,7 +93,7 @@ class TestSVG2Paths(unittest.TestCase):
         """ Test reading svg object contained in a string without svg attributes"""
         with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
             # read entire file into string
-            file_content: str = file.read()
+            file_content = file.read()
 
             paths, _ = svg_string2paths(file_content)
 
@@ -103,7 +103,7 @@ class TestSVG2Paths(unittest.TestCase):
         """ Test reading svg object contained in a string with svg attributes"""
         with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
             # read entire file into string
-            file_content: str = file.read()
+            file_content = file.read()
 
             paths, _, _ = svg_string2paths2(file_content)
 

--- a/test/test_svg2paths.py
+++ b/test/test_svg2paths.py
@@ -74,7 +74,7 @@ class TestSVG2Paths(unittest.TestCase):
             self.assertEqual(len(paths), 2)
 
     def test_from_stringio(self):
-        """ Test reading svg object contained in an StringIO object """
+        """ Test reading svg object contained in a StringIO object """
         with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
             # read entire file into string
             file_content: str = file.read()
@@ -86,5 +86,25 @@ class TestSVG2Paths(unittest.TestCase):
             file_as_stringio.seek(0)
 
             paths, _ = svg2paths(file_as_stringio)
+
+            self.assertEqual(len(paths), 2)
+
+    def test_from_string_without_svg_attrs(self):
+        """ Test reading svg object contained in a string without svg attributes"""
+        with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
+            # read entire file into string
+            file_content: str = file.read()
+
+            paths, _ = svg_string2paths(file_content)
+
+            self.assertEqual(len(paths), 2)
+
+    def test_from_string_with_svg_attrs(self):
+        """ Test reading svg object contained in a string with svg attributes"""
+        with open(join(dirname(__file__), 'polygons.svg'), 'r') as file:
+            # read entire file into string
+            file_content: str = file.read()
+
+            paths, _, _ = svg_string2paths2(file_content)
 
             self.assertEqual(len(paths), 2)

--- a/test/test_svg2paths.py
+++ b/test/test_svg2paths.py
@@ -81,11 +81,7 @@ class TestSVG2Paths(unittest.TestCase):
             # read entire file into string
             file_content = file.read()
             # prepare stringio object
-            file_as_stringio = StringIO()
-            # paste file content into it
-            file_as_stringio.write(file_content)
-            # reset curser to its beginning
-            file_as_stringio.seek(0)
+            file_as_stringio = StringIO(file_content)
 
             paths, _ = svg2paths(file_as_stringio)
 


### PR DESCRIPTION
I had the same problem as described in #138. Since his PR #139 after having received feedback from @tatarize seemed to no longer be under active development, I decided to give it a shot my self trying to take into account the suggestions by @tatarize. 

I basically check in both the function `svg2paths` and the class `Document` if the passed object is a `str`. If so it is treated as a file location just as before. In every other case the object is assumed to be file-like (that is, having at least a `read` function) and is then passed directly into the respective XML parsers which already differentiate correctly in strings describing a file location on disc and file-like objects providing the data directly. This then supports files opened with the build-in `open` function as well as `StringIO` objects for pipelining svg objects between different packages.

Moreover, I implemented overloads for `svg2paths` and `svg2paths2`, namely `svg_string2paths` and `svg_string2paths2` that take a `str` object, wrap it in a `StringIO` object and then call the already existing functions that were alternated to be able to handle this kind of object. A static factory method  `from_svg_string(str)` was also added to the `Document` class to allow creating such an object from a `str` object. This also internal wraps the `str` object into a `StringIO` object. 

I provide tests for the `svg2paths` functions, the changed ctor of `Document` and the new factory method, to test that they all work for file system paths, files, StringIO objects, and strings.

We might want to add some information for this new gained flexibility in the documentation. I didn't know, however, which file I would need to manipulate the ipython notebook or the markdown and whether the other one is autogenerated in some way from the other.

If you dislike any of my changes please feel free to make any changes to my proposed changes.