### PR TITLE
adjust parsing to raise nicer exceptions

### DIFF
--- a/test/test_parsing.py
+++ b/test/test_parsing.py
@@ -178,10 +178,20 @@ class TestParser(unittest.TestCase):
         path2 = Path(Line(-3.4e+38 + 3.4e+38j, -3.4e-38 + 3.4e-38j))
         self.assertEqual(path1, path2)
 
-    def test_errors(self):
-        self.assertRaises(ValueError, parse_path,
-                          'M 100 100 L 200 200 Z 100 200')
+    def test_error_missing_command(self):
+        with self.assertRaises(SyntaxError) as e:
+            parse_path('M 100 100 L 200 200 Z 100 200')
+        assert "missing command" in e.exception.msg
 
+    def test_error_invalid_token(self):
+        with self.assertRaises(SyntaxError) as e:
+            parse_path("M 0 \n1 N 2 3")
+        assert "invalid token" in e.exception.msg
+    
+    def test_error_not_enough_arguments(self):
+        with self.assertRaises(SyntaxError) as e:
+            Path("M 0 1\n 2")
+        assert "not enough arguments" in e.exception.msg
 
     def test_transform(self):
 


### PR DESCRIPTION
The current parsing works great on well formed path but could be improved when it comes to handling invalid cases:
1. the "Unallowed implicit command" error message mentions an internal token index
2. invalid tokens are silently dropped
3. the parser can run out of tokens and let an `IndexError: pop from empty list` through
```
Path('1,2')
ValueError: Unallowed implicit command in 1,2, position -1

Path('M 100 100 L 200 200 Z 100 200')
ValueError: Unallowed implicit command in M 100 100 L 200 200 Z 100 200, position 7

Path('M 0 1 L 0 0 L 0 0z1')
ValueError: Unallowed implicit command in M 0 1 L 0 0 L 0 0z1, position 8

Path('M 1 2 3')
IndexError: pop from empty list

Path('M 0 1 N 2 3')
Path(Line(start=1j, end=(2+3j)))

Path('M 0 1 C 1 2 3 4\n      5 foo')
IndexError: pop from empty list
```

This PR catches cases 2. and 3. and raises a standard `SyntaxError` highlighting the error location in the `d` string in all 3 cases:
```
Path('1,2')
  File "<svg-d-string>", line 1
    1,2
    ^
SyntaxError: missing command

Path('M 100 100 L 200 200 Z 100 200')
  File "<svg-d-string>", line 1
    M 100 100 L 200 200 Z 100 200
                          ^^^
SyntaxError: missing command

Path('M 0 1 L 0 0 L 0 0z1')
  File "<svg-d-string>", line 1
    M 0 1 L 0 0 L 0 0z1
                      ^
SyntaxError: missing command

Path('M 1 2 3')
  File "<svg-d-string>", line 1
    M 1 2 3
          ^
SyntaxError: not enough arguments

Path('M 0 1 N 2 3')
  File "<svg-d-string>", line 1
    M 0 1 N 2 3
         ^^^
SyntaxError: invalid token ' N '

Path('M 0 1 C 1 2 3 4\n      5 foo')
  File "<svg-d-string>", line 2
    5 foo
     ^^^^
SyntaxError: invalid token ' foo'
```