### PR TITLE
Add error message for invalid Path point range

### DIFF
--- a/svgpathtools/path.py
+++ b/svgpathtools/path.py
@@ -2573,6 +2573,8 @@ class Path(MutableSequence):
         # Shortcuts
         if len(self._segments) == 0:
             raise ValueError("This path contains no segments!")
+        if pos < 0.0 or pos > 1.0:
+            raise ValueError("Pos for Path.point must be between 0 and 1, but was {}".format(pos))
         if pos == 0.0:
             return self._segments[0].point(pos)
         if pos == 1.0:


### PR DESCRIPTION
As described on the README, "these parameterizations are defined over the domain 0 <= t <= 1". Currently, the user gets "Something went wrong" which is not very helpful.