### PR TITLE
Bugfix for rotated ellipse

### DIFF
--- a/svgpathtools/path.py
+++ b/svgpathtools/path.py
@@ -334,7 +334,7 @@ def transform(curve, tf):
         new_radius = complex(rx, ry)
 
         xeigvec = eigvecs[:, 0]
-        rot = np.degrees(np.arccos(xeigvec[0]))
+        rot = np.degrees(np.arctan2(xeigvec[1], xeigvec[0]))
 
         if new_radius.real == 0 or new_radius.imag == 0 :
             return Line(new_start, new_end)


### PR DESCRIPTION
Thanks for this great library!

I was playing with rotated ellipses and noticed a bug in how the rotation angle is extracted from the transform function.
Essentially, `arccos` wasn't computing the right sign for some angles, so I replaced it with `arctan2` and added a bunch of unit tests.

### Reproducer:
Before this PR, the following input
```svg
<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg" style="fill:green;stroke:black;stroke-width:1.5">
    <ellipse cx="40" cy="80" rx="15" ry="20" transform="rotate(-45 40 80)"/>
</svg>
```
![image](https://github.com/mathandy/svgpathtools/assets/5626552/28b6d573-e007-4e74-81ff-bacac6dcff86)

generated these arc paths:
```svg
<?xml version="1.0" ?>
<svg:svg xmlns:svg="http://www.w3.org/2000/svg" width="200" height="200" style="fill:red;stroke:black;stroke-width:1.5">
    <path d="M 29.393398282201787,90.60660171779821 
             A 15.0,20.0 45.0 1,0 50.60660171779821,69.39339828220179 
             A 15.0,20.0 45.0 1,0 29.393398282201787,90.60660171779821"/>
</svg:svg>
```
**Note:** The angle is 45 degrees instead of -45 degrees, which is rendered as:
![image](https://github.com/mathandy/svgpathtools/assets/5626552/817aa1c1-1e9c-4660-892c-058c623c4871)
(note: I changed the fill color for easier comparison).

After this PR, the correct arc paths are produced:
```svg
<?xml version="1.0" ?>
<svg:svg xmlns:svg="http://www.w3.org/2000/svg" width="200" height="200" style="fill:red;stroke:black;stroke-width:1.5">
    <path d="M 29.393398282201787,90.60660171779821 
             A 15.0,20.0 -44.99999999999999 1,0 50.60660171779821,69.39339828220179 
             A 15.0,20.0 -44.99999999999999 1,0 29.393398282201787,90.60660171779821"/>
</svg:svg>
```
![image](https://github.com/mathandy/svgpathtools/assets/5626552/5af90143-b83b-4f5b-8f4c-b204748d1da6)



