### PR TITLE
Bugfix for parsing rounded rect instances

### DIFF
--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -93,7 +93,8 @@ def rect2pathd(rect):
     rectangle object and proceed counter-clockwise."""
     x, y = float(rect.get('x', 0)), float(rect.get('y', 0))
     w, h = float(rect.get('width', 0)), float(rect.get('height', 0))
-    if 'rx' in rect or 'ry' in rect:
+
+    if 'rx' in rect.keys() or 'ry' in rect.keys():
 
         # if only one, rx or ry, is present, use that value for both
         # https://developer.mozilla.org/en-US/docs/Web/SVG/Element/rect

--- a/test/test_groups.py
+++ b/test/test_groups.py
@@ -46,6 +46,61 @@ class TestGroups(unittest.TestCase):
         self.check_values(tf.dot(v_s), actual.start)
         self.check_values(tf.dot(v_e), actual.end)
 
+    def test_nonrounded_rect(self):
+        # Check that (nonrounded) rect is parsed properly
+
+        x, y = 10, 10
+        w, h = 100, 100
+
+        doc = Document.from_svg_string("\n".join(
+            [
+                '<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"',
+                '     style="fill:green;stroke:black;stroke-width:1.5">',
+                f'  <rect x="{x}" y="{y}" width="{w}" height="{h}"/>',
+                "</svg>",
+            ]
+        ))
+
+        line_count,arc_count = 0, 0
+
+        for p in doc.paths():
+            for s in p:
+                if isinstance(s, Line):
+                    line_count += 1
+                if isinstance(s, Arc):
+                    arc_count += 1
+
+        self.assertEqual(line_count, 4)
+        self.assertEqual(arc_count, 0)
+
+    def test_rounded_rect(self):
+        # Check that rounded rect is parsed properly
+
+        x, y = 10, 10
+        rx, ry = 15, 12
+        w, h = 100, 100
+
+        doc = Document.from_svg_string("\n".join(
+            [
+                '<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"',
+                '     style="fill:green;stroke:black;stroke-width:1.5">',
+                f'  <rect x="{x}" y="{y}" rx="{rx}" ry="{ry}" width="{w}" height="{h}"/>',
+                "</svg>",
+            ]
+        ))
+
+        line_count,arc_count = 0, 0
+
+        for p in doc.paths():
+            for s in p:
+                if isinstance(s, Line):
+                    line_count += 1
+                if isinstance(s, Arc):
+                    arc_count += 1
+
+        self.assertEqual(line_count, 4)
+        self.assertEqual(arc_count, 4)
+
     def test_group_transform(self):
         # The input svg has a group transform of "scale(1,-1)", which
         # can mess with Arc sweeps.

--- a/test/test_groups.py
+++ b/test/test_groups.py
@@ -52,16 +52,18 @@ class TestGroups(unittest.TestCase):
         x, y = 10, 10
         w, h = 100, 100
 
-        doc = Document.from_svg_string("\n".join(
-            [
-                '<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"',
-                '     style="fill:green;stroke:black;stroke-width:1.5">',
-                f'  <rect x="{x}" y="{y}" width="{w}" height="{h}"/>',
-                "</svg>",
-            ]
-        ))
+        doc = Document.from_svg_string(
+            "\n".join(
+                [
+                    '<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"',
+                    '     style="fill:green;stroke:black;stroke-width:1.5">',
+                    f'  <rect x="{x}" y="{y}" width="{w}" height="{h}"/>',
+                    "</svg>",
+                ]
+            )
+        )
 
-        line_count,arc_count = 0, 0
+        line_count, arc_count = 0, 0
 
         for p in doc.paths():
             for s in p:
@@ -80,16 +82,18 @@ class TestGroups(unittest.TestCase):
         rx, ry = 15, 12
         w, h = 100, 100
 
-        doc = Document.from_svg_string("\n".join(
-            [
-                '<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"',
-                '     style="fill:green;stroke:black;stroke-width:1.5">',
-                f'  <rect x="{x}" y="{y}" rx="{rx}" ry="{ry}" width="{w}" height="{h}"/>',
-                "</svg>",
-            ]
-        ))
+        doc = Document.from_svg_string(
+            "\n".join(
+                [
+                    '<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"',
+                    '     style="fill:green;stroke:black;stroke-width:1.5">',
+                    f'  <rect x="{x}" y="{y}" rx="{rx}" ry="{ry}" width="{w}" height="{h}"/>',
+                    "</svg>",
+                ]
+            )
+        )
 
-        line_count,arc_count = 0, 0
+        line_count, arc_count = 0, 0
 
         for p in doc.paths():
             for s in p:

--- a/test/test_svg2paths.py
+++ b/test/test_svg2paths.py
@@ -81,32 +81,47 @@ class TestSVG2Paths(unittest.TestCase):
         shutil.rmtree(tmpdir)
 
     def test_rect2pathd(self):
-        non_rounded_dict = {"x":"10", "y":"10", "width":"100","height":"100"}
-        self.assertEqual(rect2pathd(non_rounded_dict), 'M10.0 10.0 L 110.0 10.0 L 110.0 110.0 L 10.0 110.0 z')
+        non_rounded_dict = {"x": "10", "y": "10", "width": "100", "height": "100"}
+        self.assertEqual(
+            rect2pathd(non_rounded_dict),
+            "M10.0 10.0 L 110.0 10.0 L 110.0 110.0 L 10.0 110.0 z",
+        )
 
-        non_rounded_svg = u"""<?xml version="1.0" encoding="UTF-8"?>
+        non_rounded_svg = """<?xml version="1.0" encoding="UTF-8"?>
           <svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" width="200mm" height="200mm" version="1.1">
               <rect id="non_rounded" x="10" y="10" width="100" height="100" />
           </svg>"""
-        
+
         paths, _ = svg2paths(StringIO(non_rounded_svg))
         self.assertEqual(len(paths), 1)
         self.assertTrue(paths[0].isclosed())
-        self.assertEqual(paths[0].d(use_closed_attrib=True), 'M 10.0,10.0 L 110.0,10.0 L 110.0,110.0 L 10.0,110.0 Z')
-        self.assertEqual(paths[0].d(use_closed_attrib=False), 'M 10.0,10.0 L 110.0,10.0 L 110.0,110.0 L 10.0,110.0 L 10.0,10.0')
+        self.assertEqual(
+            paths[0].d(use_closed_attrib=True),
+            "M 10.0,10.0 L 110.0,10.0 L 110.0,110.0 L 10.0,110.0 Z",
+        )
+        self.assertEqual(
+            paths[0].d(use_closed_attrib=False),
+            "M 10.0,10.0 L 110.0,10.0 L 110.0,110.0 L 10.0,110.0 L 10.0,10.0",
+        )
 
-        rounded_dict = {"x":"10", "y":"10", "width":"100","height":"100", "rx":"15", "ry": "12"}
-        self.assertEqual(rect2pathd(rounded_dict), "M 25.0 10.0 L 95.0 10.0 A 15.0 12.0 0 0 1 110.0 22.0 L 110.0 98.0 A 15.0 12.0 0 0 1 95.0 110.0 L 25.0 110.0 A 15.0 12.0 0 0 1 10.0 98.0 L 10.0 22.0 A 15.0 12.0 0 0 1 25.0 10.0 z")
+        rounded_dict = {"x": "10", "y": "10", "width": "100","height": "100", "rx": "15", "ry": "12"}
+        self.assertEqual(
+            rect2pathd(rounded_dict),
+            "M 25.0 10.0 L 95.0 10.0 A 15.0 12.0 0 0 1 110.0 22.0 L 110.0 98.0 A 15.0 12.0 0 0 1 95.0 110.0 L 25.0 110.0 A 15.0 12.0 0 0 1 10.0 98.0 L 10.0 22.0 A 15.0 12.0 0 0 1 25.0 10.0 z",
+        )
 
-        rounded_svg = u"""<?xml version="1.0" encoding="UTF-8"?>
+        rounded_svg = """<?xml version="1.0" encoding="UTF-8"?>
           <svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" width="200mm" height="200mm" version="1.1">
               <rect id="rounded" x="10" y="10" width="100" height ="100" rx="15" ry="12" />
           </svg>"""
-        
+
         paths, _ = svg2paths(StringIO(rounded_svg))
         self.assertEqual(len(paths), 1)
         self.assertTrue(paths[0].isclosed())
-        self.assertEqual(paths[0].d(), "M 25.0,10.0 L 95.0,10.0 A 15.0,12.0 0.0 0,1 110.0,22.0 L 110.0,98.0 A 15.0,12.0 0.0 0,1 95.0,110.0 L 25.0,110.0 A 15.0,12.0 0.0 0,1 10.0,98.0 L 10.0,22.0 A 15.0,12.0 0.0 0,1 25.0,10.0")
+        self.assertEqual(
+            paths[0].d(),
+            "M 25.0,10.0 L 95.0,10.0 A 15.0,12.0 0.0 0,1 110.0,22.0 L 110.0,98.0 A 15.0,12.0 0.0 0,1 95.0,110.0 L 25.0,110.0 A 15.0,12.0 0.0 0,1 10.0,98.0 L 10.0,22.0 A 15.0,12.0 0.0 0,1 25.0,10.0",
+        )
 
     def test_from_file_path_string(self):
         """Test reading svg from file provided as path"""

--- a/test/test_svg2paths.py
+++ b/test/test_svg2paths.py
@@ -81,10 +81,32 @@ class TestSVG2Paths(unittest.TestCase):
         shutil.rmtree(tmpdir)
 
     def test_rect2pathd(self):
-        non_rounded = {"x":"10", "y":"10", "width":"100","height":"100"}
-        self.assertEqual(rect2pathd(non_rounded), 'M10.0 10.0 L 110.0 10.0 L 110.0 110.0 L 10.0 110.0 z')
-        rounded = {"x":"10", "y":"10", "width":"100","height":"100", "rx":"15", "ry": "12"}
-        self.assertEqual(rect2pathd(rounded), "M 25.0 10.0 L 95.0 10.0 A 15.0 12.0 0 0 1 110.0 22.0 L 110.0 98.0 A 15.0 12.0 0 0 1 95.0 110.0 L 25.0 110.0 A 15.0 12.0 0 0 1 10.0 98.0 L 10.0 22.0 A 15.0 12.0 0 0 1 25.0 10.0 z")
+        non_rounded_dict = {"x":"10", "y":"10", "width":"100","height":"100"}
+        self.assertEqual(rect2pathd(non_rounded_dict), 'M10.0 10.0 L 110.0 10.0 L 110.0 110.0 L 10.0 110.0 z')
+
+        non_rounded_svg = u"""<?xml version="1.0" encoding="UTF-8"?>
+          <svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" width="200mm" height="200mm" version="1.1">
+              <rect id="non_rounded" x="10" y="10" width="100" height="100" />
+          </svg>"""
+        
+        paths, _ = svg2paths(StringIO(non_rounded_svg))
+        self.assertEqual(len(paths), 1)
+        self.assertTrue(paths[0].isclosed())
+        self.assertEqual(paths[0].d(use_closed_attrib=True), 'M 10.0,10.0 L 110.0,10.0 L 110.0,110.0 L 10.0,110.0 Z')
+        self.assertEqual(paths[0].d(use_closed_attrib=False), 'M 10.0,10.0 L 110.0,10.0 L 110.0,110.0 L 10.0,110.0 L 10.0,10.0')
+
+        rounded_dict = {"x":"10", "y":"10", "width":"100","height":"100", "rx":"15", "ry": "12"}
+        self.assertEqual(rect2pathd(rounded_dict), "M 25.0 10.0 L 95.0 10.0 A 15.0 12.0 0 0 1 110.0 22.0 L 110.0 98.0 A 15.0 12.0 0 0 1 95.0 110.0 L 25.0 110.0 A 15.0 12.0 0 0 1 10.0 98.0 L 10.0 22.0 A 15.0 12.0 0 0 1 25.0 10.0 z")
+
+        rounded_svg = u"""<?xml version="1.0" encoding="UTF-8"?>
+          <svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" width="200mm" height="200mm" version="1.1">
+              <rect id="rounded" x="10" y="10" width="100" height ="100" rx="15" ry="12" />
+          </svg>"""
+        
+        paths, _ = svg2paths(StringIO(rounded_svg))
+        self.assertEqual(len(paths), 1)
+        self.assertTrue(paths[0].isclosed())
+        self.assertEqual(paths[0].d(), "M 25.0,10.0 L 95.0,10.0 A 15.0,12.0 0.0 0,1 110.0,22.0 L 110.0,98.0 A 15.0,12.0 0.0 0,1 95.0,110.0 L 25.0,110.0 A 15.0,12.0 0.0 0,1 10.0,98.0 L 10.0,22.0 A 15.0,12.0 0.0 0,1 25.0,10.0")
 
     def test_from_file_path_string(self):
         """Test reading svg from file provided as path"""


### PR DESCRIPTION
This PR contains a minor bugfix for parsing rounded rectangles.

When calling `rect2pathd` through the `Document` class, the passed in `Element` instance did not directly expose its `rx` and `ry` attributes, which can be accessed through the `keys()` method.

I added unit tests for this case and verified that everything continues to work when calling `rect2pathd` with a dictionary and with the `svg2paths` function on an SVG document.