### PR TITLE
Upstream svgpathtools improvement

### DIFF
--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -31,8 +31,8 @@ def ellipse2pathd(ellipse):
     """converts the parameters from an ellipse or a circle to a string for a 
     Path object d-attribute"""
 
-    cx = ellipse.get('cx', 0)
-    cy = ellipse.get('cy', 0)
+    cx = (ellipse.get('cx', 0) or 0)
+    cy = (ellipse.get('cy', 0) or 0)
     rx = ellipse.get('rx', None)
     ry = ellipse.get('ry', None)
     r = ellipse.get('r', None)
@@ -40,8 +40,8 @@ def ellipse2pathd(ellipse):
     if r is not None:
         rx = ry = float(r)
     else:
-        rx = float(rx)
-        ry = float(ry)
+        rx = float(rx or 0)
+        ry = float(ry or 0)
 
     cx = float(cx)
     cy = float(cy)
@@ -66,7 +66,11 @@ def polyline2pathd(polyline, is_polygon=False):
     if isinstance(polyline, str):
         points = polyline
     else:
-        points = COORD_PAIR_TMPLT.findall(polyline.get('points', ''))
+        raw_points = polyline.get('points', '')
+        if not raw_points:
+            points = [(0,0)]
+        else:
+            points = COORD_PAIR_TMPLT.findall(raw_points)
 
     closed = (float(points[0][0]) == float(points[-1][0]) and
               float(points[0][1]) == float(points[-1][1]))
@@ -97,8 +101,8 @@ def rect2pathd(rect):
     
     The rectangle will start at the (x,y) coordinate specified by the 
     rectangle object and proceed counter-clockwise."""
-    x, y = float(rect.get('x', 0)), float(rect.get('y', 0))
-    w, h = float(rect.get('width', 0)), float(rect.get('height', 0))
+    x, y = float(rect.get('x', 0) or 0), float(rect.get('y', 0) or 0)
+    w, h = float(rect.get('width', 0) or 0), float(rect.get('height', 0) or 0)
     if 'rx' in rect or 'ry' in rect:
 
         # if only one, rx or ry, is present, use that value for both

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -86,11 +86,7 @@ def polyline2pathd(polyline, is_polygon=False):
     if isinstance(polyline, str):
         points = polyline
     else:
-        raw_points = polyline.get('points', '')
-        if not raw_points:
-            points = [(0,0)]
-        else:
-            points = COORD_PAIR_TMPLT.findall(raw_points)
+        points = COORD_PAIR_TMPLT.findall(polyline.get('points', ''))
 
     closed = (float(points[0][0]) == float(points[-1][0]) and
               float(points[0][1]) == float(points[-1][1]))

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -1,3 +1,6 @@
+#
+# Modified by NXP 2024
+#
 """This submodule contains tools for creating path objects from SVG files.
 The main tool being the svg2paths() function."""
 

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -50,12 +50,21 @@ def ellipse2pathd(ellipse):
     rxKappa = rx * PATH_KAPPA;
     ryKappa = ry * PATH_KAPPA;
 
+    #According to the SVG specification (https://lists.w3.org/Archives/Public/www-archive/2005May/att-0005/SVGT12_Main.pdf),
+    #Section 9.4, "The 'ellipse' element": "The arc of an 'ellipse' element begins at the "3 o'clock" point on
+    #the radius and progresses towards the "9 o'clock". Therefore, the ellipse begins at the rightmost point
+    #and progresses clockwise.
     d = ''
-    d += 'M ' + str(cx) + ' ' + str(cy - ry)
-    d += ' C ' + str(cx + rxKappa) + ' ' + str(cy - ry) + ' ' + str(cx + rx) + ' ' + str(cy - ryKappa) + ' ' + str(cx + rx) + ' ' + str(cy)
+    # Move to the rightmost point
+    d += 'M ' + str(cx + rx) + ' ' + str(cy)
+    # Draw bottom-right quadrant
     d += ' C ' + str(cx + rx) + ' ' + str(cy + ryKappa) + ' ' + str(cx + rxKappa) + ' ' + str(cy + ry) + ' ' + str(cx) + ' ' + str(cy + ry)
+    # Draw bottom-left quadrant
     d += ' C ' + str(cx - rxKappa) + ' ' + str(cy + ry) + ' ' + str(cx - rx) + ' ' + str(cy + ryKappa) + ' ' + str(cx - rx) + ' ' + str(cy)
+    # Draw top-left quadrant
     d += ' C ' + str(cx - rx) + ' ' + str(cy - ryKappa) + ' ' + str(cx - rxKappa) + ' ' + str(cy - ry) + ' ' + str(cx) + ' ' + str(cy - ry)
+    # Draw top-right quadrant
+    d += ' C ' + str(cx + rxKappa) + ' ' + str(cy - ry) + ' ' + str(cx + rx) + ' ' + str(cy - ryKappa) + ' ' + str(cx + rx) + ' ' + str(cy)
     
     return d + ' Z'
 

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -46,12 +46,18 @@ def ellipse2pathd(ellipse):
     cx = float(cx)
     cy = float(cy)
 
-    d = ''
-    d += 'M' + str(cx - rx) + ',' + str(cy)
-    d += 'a' + str(rx) + ',' + str(ry) + ' 0 1,0 ' + str(2 * rx) + ',0'
-    d += 'a' + str(rx) + ',' + str(ry) + ' 0 1,0 ' + str(-2 * rx) + ',0'
+    PATH_KAPPA = 0.552284
+    rxKappa = rx * PATH_KAPPA;
+    ryKappa = ry * PATH_KAPPA;
 
-    return d + 'z'
+    d = ''
+    d += 'M ' + str(cx) + ' ' + str(cy - ry)
+    d += ' C ' + str(cx + rxKappa) + ' ' + str(cy - ry) + ' ' + str(cx + rx) + ' ' + str(cy - ryKappa) + ' ' + str(cx + rx) + ' ' + str(cy)
+    d += ' C ' + str(cx + rx) + ' ' + str(cy + ryKappa) + ' ' + str(cx + rxKappa) + ' ' + str(cy + ry) + ' ' + str(cx) + ' ' + str(cy + ry)
+    d += ' C ' + str(cx - rxKappa) + ' ' + str(cy + ry) + ' ' + str(cx - rx) + ' ' + str(cy + ryKappa) + ' ' + str(cx - rx) + ' ' + str(cy)
+    d += ' C ' + str(cx - rx) + ' ' + str(cy - ryKappa) + ' ' + str(cx - rxKappa) + ' ' + str(cy - ry) + ' ' + str(cx) + ' ' + str(cy - ry)
+    
+    return d + ' Z'
 
 
 def polyline2pathd(polyline, is_polygon=False):

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -99,7 +99,7 @@ def polyline2pathd(polyline, is_polygon=False):
     return d
 
 
-def polygon2pathd(polyline, is_polygon):
+def polygon2pathd(polyline, is_polygon=True):
     """converts the string from a polygon points-attribute to a string 
     for a Path object d-attribute.
     Note:  For a polygon made from n points, the resulting path will be

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -30,7 +30,7 @@ def path2pathd(path):
     return path.get('d', '')
 
 
-def ellipse2pathd(ellipse):
+def ellipse2pathd(ellipse, use_cubics=False):
     """converts the parameters from an ellipse or a circle to a string for a 
     Path object d-attribute"""
 
@@ -49,25 +49,33 @@ def ellipse2pathd(ellipse):
     cx = float(cx)
     cy = float(cy)
 
-    PATH_KAPPA = 0.552284
-    rxKappa = rx * PATH_KAPPA;
-    ryKappa = ry * PATH_KAPPA;
+    if use_cubics:
 
-    #According to the SVG specification (https://lists.w3.org/Archives/Public/www-archive/2005May/att-0005/SVGT12_Main.pdf),
-    #Section 9.4, "The 'ellipse' element": "The arc of an 'ellipse' element begins at the "3 o'clock" point on
-    #the radius and progresses towards the "9 o'clock". Therefore, the ellipse begins at the rightmost point
-    #and progresses clockwise.
-    d = ''
-    # Move to the rightmost point
-    d += 'M ' + str(cx + rx) + ' ' + str(cy)
-    # Draw bottom-right quadrant
-    d += ' C ' + str(cx + rx) + ' ' + str(cy + ryKappa) + ' ' + str(cx + rxKappa) + ' ' + str(cy + ry) + ' ' + str(cx) + ' ' + str(cy + ry)
-    # Draw bottom-left quadrant
-    d += ' C ' + str(cx - rxKappa) + ' ' + str(cy + ry) + ' ' + str(cx - rx) + ' ' + str(cy + ryKappa) + ' ' + str(cx - rx) + ' ' + str(cy)
-    # Draw top-left quadrant
-    d += ' C ' + str(cx - rx) + ' ' + str(cy - ryKappa) + ' ' + str(cx - rxKappa) + ' ' + str(cy - ry) + ' ' + str(cx) + ' ' + str(cy - ry)
-    # Draw top-right quadrant
-    d += ' C ' + str(cx + rxKappa) + ' ' + str(cy - ry) + ' ' + str(cx + rx) + ' ' + str(cy - ryKappa) + ' ' + str(cx + rx) + ' ' + str(cy)
+        PATH_KAPPA = 0.552284
+        rxKappa = rx * PATH_KAPPA;
+        ryKappa = ry * PATH_KAPPA;
+
+        #According to the SVG specification (https://lists.w3.org/Archives/Public/www-archive/2005May/att-0005/SVGT12_Main.pdf),
+        #Section 9.4, "The 'ellipse' element": "The arc of an 'ellipse' element begins at the "3 o'clock" point on
+        #the radius and progresses towards the "9 o'clock". Therefore, the ellipse begins at the rightmost point
+        #and progresses clockwise.
+        d = ''
+        # Move to the rightmost point
+        d += 'M ' + str(cx + rx) + ' ' + str(cy)
+        # Draw bottom-right quadrant
+        d += ' C ' + str(cx + rx) + ' ' + str(cy + ryKappa) + ' ' + str(cx + rxKappa) + ' ' + str(cy + ry) + ' ' + str(cx) + ' ' + str(cy + ry)
+        # Draw bottom-left quadrant
+        d += ' C ' + str(cx - rxKappa) + ' ' + str(cy + ry) + ' ' + str(cx - rx) + ' ' + str(cy + ryKappa) + ' ' + str(cx - rx) + ' ' + str(cy)
+        # Draw top-left quadrant
+        d += ' C ' + str(cx - rx) + ' ' + str(cy - ryKappa) + ' ' + str(cx - rxKappa) + ' ' + str(cy - ry) + ' ' + str(cx) + ' ' + str(cy - ry)
+        # Draw top-right quadrant
+        d += ' C ' + str(cx + rxKappa) + ' ' + str(cy - ry) + ' ' + str(cx + rx) + ' ' + str(cy - ryKappa) + ' ' + str(cx + rx) + ' ' + str(cy)
+    else:
+        d = ''
+        d += 'M' + str(cx - rx) + ',' + str(cy)
+        d += 'a' + str(rx) + ',' + str(ry) + ' 0 1,0 ' + str(2 * rx) + ',0'
+        d += 'a' + str(rx) + ',' + str(ry) + ' 0 1,0 ' + str(-2 * rx) + ',0'
+
     
     return d + ' Z'
 

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -87,13 +87,13 @@ def polyline2pathd(polyline, is_polygon=False):
     return d
 
 
-def polygon2pathd(polyline):
+def polygon2pathd(polyline, is_polygon):
     """converts the string from a polygon points-attribute to a string 
     for a Path object d-attribute.
     Note:  For a polygon made from n points, the resulting path will be
     composed of n lines (even if some of these lines have length zero).
     """
-    return polyline2pathd(polyline, True)
+    return polyline2pathd(polyline, is_polygon)
 
 
 def rect2pathd(rect):
@@ -214,7 +214,7 @@ def svg2paths(svg_file_location,
     # path strings, add to list
     if convert_polygons_to_paths:
         pgons = [dom2dict(el) for el in doc.getElementsByTagName('polygon')]
-        d_strings += [polygon2pathd(pg) for pg in pgons]
+        d_strings += [polygon2pathd(pg, True) for pg in pgons]
         attribute_dictionary_list += pgons
 
     if convert_lines_to_paths:

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -78,7 +78,7 @@ def polyline2pathd(polyline, is_polygon=False):
     # The `parse_path` call ignores redundant 'z' (closure) commands
     # e.g. `parse_path('M0 0L100 100Z') == parse_path('M0 0L100 100L0 0Z')`
     # This check ensures that an n-point polygon is converted to an n-Line path.
-    if is_polygon and closed:
+    if is_polygon or closed:
         points.append(points[0])
 
     d = 'M ' + ' L '.join('{0} {1}'.format(x,y) for x,y in points)

--- a/svgpathtools/svg_to_paths.py
+++ b/svgpathtools/svg_to_paths.py
@@ -77,9 +77,9 @@ def polyline2pathd(polyline, is_polygon=False):
     if is_polygon and closed:
         points.append(points[0])
 
-    d = 'M' + 'L'.join('{0} {1}'.format(x,y) for x,y in points)
+    d = 'M ' + ' L '.join('{0} {1}'.format(x,y) for x,y in points)
     if is_polygon or closed:
-        d += 'z'
+        d += ' z'
     return d
 
 
@@ -127,7 +127,7 @@ def rect2pathd(rect):
     x2, y2 = x + w, y + h
     x3, y3 = x, y + h
 
-    d = ("M{} {} L {} {} L {} {} L {} {} z"
+    d = ("M {} {} L {} {} L {} {} L {} {} z"
          "".format(x0, y0, x1, y1, x2, y2, x3, y3))
         
     return d


### PR DESCRIPTION
Fixes [#232](https://github.com/mathandy/svgpathtools/issues/232)

Some GPU does not have 'arc' so we can use cubic bezier for such case.
When GPU does not support 'arc' command Circle can be rendered using 2 arcs

@mathandy Please review and let us know if any changes are required.


