### PR TITLE
add floating point stabiity test

### DIFF
--- a/test/test_generation.py
+++ b/test/test_generation.py
@@ -82,6 +82,12 @@ class TestGeneration(unittest.TestCase):
         psf = 'M 0.0,0.0 L 340.0,-10.0 L 100.0,100.0 L 200.0,0.0'
         self.assertTrue(parse_path(path).d() in (ps, psf))
 
+    def test_floating_point_stability(self):
+        # Check that reading and then outputting a d-string
+        # does not introduce floating point error noise.
+        path = "M 70.63,10.42 C 0.11,0.33 -0.89,2.09 -1.54,2.45 C -4.95,2.73 -17.52,7.24 -39.46,11.04"
+        self.assertEqual(parse_path(path).d(), path)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The floating point issue I mentioned in https://github.com/mathandy/svgpathtools/issues/223 has been fixed. (I'm not sure exactly where.)

This change adds just a test from https://github.com/mathandy/svgpathtools/pull/225 to help make sure the issue does not get reintroduced.