### PR TITLE
Bugfix for transformations on Arcs

### DIFF
--- a/svgpathtools/path.py
+++ b/svgpathtools/path.py
@@ -327,7 +327,7 @@ def transform(curve, tf):
         invT = np.linalg.inv(tf[:2,:2])
         D = reduce(np.matmul, [invT.T, Q, invT])
 
-        eigvals, eigvecs = np.linalg.eigh(D)
+        eigvals, eigvecs = np.linalg.eigh(0.5*(D+D.T))  # symmetrized in case of floating point error; D already symmetric
 
         rx = 1 / np.sqrt(eigvals[0])
         ry = 1 / np.sqrt(eigvals[1])

--- a/svgpathtools/path.py
+++ b/svgpathtools/path.py
@@ -327,7 +327,7 @@ def transform(curve, tf):
         invT = np.linalg.inv(tf[:2,:2])
         D = reduce(np.matmul, [invT.T, Q, invT])
 
-        eigvals, eigvecs = np.linalg.eig(D)
+        eigvals, eigvecs = np.linalg.eigh(D)
 
         rx = 1 / np.sqrt(eigvals[0])
         ry = 1 / np.sqrt(eigvals[1])


### PR DESCRIPTION
When loading an SVG with rounded rectangles and transforms, the `Path` transform function gave the following error when transforming some of the `Arc` paths:
```
TypeError: ufunc 'arctan2' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

After digging into it, some rotations generated eigenvectors with complex values rather than real values.

The fix was to use the Hermitian form (`np.linalg.eigh`) instead of `np.linalg.eig` for the eigenvector/value computations which is guaranteed to return reals. As far as I can tell, this is valid based on how the `D` matrix is generated as `invT * Q * T`.

The following SVG is (close to) a minimal reproducer:
```svg
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg width="416.53091" height="506.883"
   viewBox="0 0 416.53091 506.88299"
   version="1.1"
   xmlns="http://www.w3.org/2000/svg" >
  <g transform="translate(-104.31227,-107.15344)" style="display:inline">
    <rect
       x="116.40955"
       y="202.60011"
       width="32"
       height="10"
       rx="5"
       ry="5"
       fill="#8338ec"
       transform="rotate(-8)"
       id="rect10" />
  </g>
</svg>
```

I added a test to `ArcTest` that triggers the error before the bugfix and is resolved by the bugfix.
