### PR TITLE
Parse SVG arc paths with packed large-arc/sweep flags (fixes #129)

### DIFF
--- a/svgpathtools/path.py
+++ b/svgpathtools/path.py
@@ -46,6 +46,35 @@ UPPERCASE = set('MZLHVCSQTA')
 
 COMMAND_RE = re.compile(r"([MmZzLlHhVvCcSsQqTtAa])")
 FLOAT_RE = re.compile(r"[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?")
+# In an elliptical arc argument the large-arc-flag and sweep-flag are each a
+# single "0"/"1" character that, unlike the other fields, may be written with
+# no separator before the next number (e.g. "0110 0" == "0 1 10 0"); see the
+# SVG path grammar: https://www.w3.org/TR/SVG/paths.html#PathDataBNF
+ARC_FLAG_RE = re.compile(r"[01]")
+WSP_COMMA_RE = re.compile(r"[\s,]*")
+
+
+def _tokenize_arc_args(arg_chunk):
+    """Yield the tokens of one or more seven-field elliptical-arc groups."""
+    pos = 0
+    field = 0
+    n = len(arg_chunk)
+    while True:
+        sep = WSP_COMMA_RE.match(arg_chunk, pos)
+        if sep:
+            pos = sep.end()
+        if pos >= n:
+            return
+        match = None
+        if field % 7 in (3, 4):
+            match = ARC_FLAG_RE.match(arg_chunk, pos)
+        if match is None:
+            match = FLOAT_RE.match(arg_chunk, pos)
+        if match is None:
+            return
+        yield match.group()
+        pos = match.end()
+        field += 1
 
 # Default Parameters ##########################################################
 
@@ -3191,11 +3220,20 @@ class Path(MutableSequence):
         return zip(a, b)
 
     def _tokenize_path(self, pathdef):
+        command = None
         for x in COMMAND_RE.split(pathdef):
             if x in COMMANDS:
+                command = x
                 yield x
-            for token in FLOAT_RE.findall(x):
-                yield token
+                continue
+            if command in ('A', 'a'):
+                # Arc arguments need flag-aware tokenizing; the other commands
+                # only carry plain numbers.
+                for token in _tokenize_arc_args(x):
+                    yield token
+            else:
+                for token in FLOAT_RE.findall(x):
+                    yield token
 
     def _parse_path(self, pathdef, current_pos=0j, tree_element=None):
         # In the SVG specs, initial movetos are absolute, even if

--- a/test/test_parsing.py
+++ b/test/test_parsing.py
@@ -170,6 +170,36 @@ class TestParser(unittest.TestCase):
         path2 = parse_path('M 100 200 c 10 -5 20 -10 30 -20')
         self.assertEqual(path1, path2)
 
+    def test_arc_flag_packing(self):
+        """Arc flags may run straight into the next number (#129)."""
+        # Each packed form must parse identically to the spaced-out form.
+        equivalent = [
+            ('M 0 0 A 5 5 0 0110 0', 'M 0 0 A 5 5 0 0 1 10 0'),
+            ('M 0 0 A 5 5 0 1110 0', 'M 0 0 A 5 5 0 1 1 10 0'),
+            ('M 0 0 A 5 5 0 0010 0', 'M 0 0 A 5 5 0 0 0 10 0'),
+            ('M 0 0 a 5 5 0 0010 0', 'M 0 0 a 5 5 0 0 0 10 0'),
+            ('M 0 0 A 5 5 0 01-10 0', 'M 0 0 A 5 5 0 0 1 -10 0'),
+            ('M 0 0 A 5 5 0 0 1 10 0 5 5 0 1120 0',
+             'M 0 0 A 5 5 0 0 1 10 0 5 5 0 1 1 20 0'),
+        ]
+        for packed, spaced in equivalent:
+            self.assertEqual(parse_path(packed), parse_path(spaced))
+
+        # The flags carry through to the resulting Arc.
+        arc = parse_path('M 0 0 A 5 5 0 0110 0')[0]
+        self.assertFalse(arc.large_arc)
+        self.assertTrue(arc.sweep)
+        self.assertEqual(arc.end, 10 + 0j)
+
+        # Real-world path from issue #129 (simple-icons "emlakjet") with packed
+        # "00" flags; this used to raise IndexError.
+        icon = 'M12 0a3.543 3.543 0 00-1.267 2.471A3.543 3.543 0 0012 0z'
+        path = parse_path(icon)
+        self.assertEqual(len(path), 2)
+        self.assertTrue(all(isinstance(seg, Arc) for seg in path))
+        self.assertFalse(path[0].large_arc)
+        self.assertFalse(path[0].sweep)
+
     def test_numbers(self):
         """Exponents and other number format cases"""
         # It can be e or E, the plus is optional, and a minimum of


### PR DESCRIPTION
Fixes #129.

### The bug

`parse_path()` raises `IndexError` on valid SVG arc commands whose `large-arc-flag`/`sweep-flag` are written without a separator before the following number:

```python
>>> from svgpathtools import parse_path
>>> parse_path("M 0 0 A 5 5 0 0110 0")
IndexError: pop from empty list
>>> parse_path("M 0 0 A 5 5 0 0 1 10 0")     # the spaced-out form works
Path(Arc(start=0j, radius=(5+5j), rotation=0.0, large_arc=False, sweep=True, end=(10+0j)))
```

Per the [SVG path grammar](https://www.w3.org/TR/SVG/paths.html#PathDataBNF), each flag is a single `"0"`/`"1"` token that **may be immediately followed by the next number with no separator**, so `0110 0` means flag `0`, flag `1`, number `10`, number `0`. Every browser and librsvg accept this, and **SVGO emits it** to save bytes — which is exactly the real-world path in #129 (the simple-icons "emlakjet" icon, `…a3.543 3.543 0 00-1.267…`).

### Root cause

`_tokenize_path` tokenizes every command's arguments with `FLOAT_RE.findall`:

```python
for token in FLOAT_RE.findall(x):
    yield token
```

`FLOAT_RE` is greedy and command-agnostic, so for an arc it reads the packed flag pair `0110` as the single number `110`. The arc branch then pops seven values (`rx, ry, rotation, large_arc, sweep, x, y`) but only five tokens exist, so `elements.pop()` empties the list → `IndexError` at `path.py:3361`.

### The fix

Tokenize arc arguments flag-aware: the two flag fields are read one `"0"`/`"1"` character at a time, while every other field stays a normal (greedy) number. The resulting token stream for a packed arc is **byte-identical** to its spaced-out form, so the existing pop-based parser is unchanged — only the tokenizer learned that arc flags are single characters. Non-arc commands keep using `FLOAT_RE.findall` exactly as before.

This mirrors the upstream `svg.path` library (from which this parser was originally copied), which already tokenizes arc flags this way.

### Tests

`test_arc_flag_packing` asserts that six packed forms (absolute and relative, a negative coordinate directly after a flag, and a two-arc group with the second packed) parse identically to their spaced-out equivalents, that the flags carry through to the resulting `Arc`, and that the real #129 simple-icons path parses instead of raising. The new test fails on `master` with the original `IndexError`; the full suite (102 tests) passes with the fix.
